### PR TITLE
Add nix build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 cabal.sandbox.config
 /selda-tests/PGConnectInfo.hs
 /selda/README.md
+result*

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,13 @@
+{ pkgs ? import <nixpkgs> {}, compiler ? "ghc802" }:
+let
+  hps = pkgs.haskell.packages.${compiler}.override {
+    overrides = self: super: with pkgs.haskell.lib; {
+      selda = self.callPackage ./selda {};
+      selda-postgresql = self.callPackage ./selda-postgresql {};
+      selda-sqlite = self.callPackage ./selda-sqlite {};
+      selda-tests = dontHaddock (self.callPackage ./selda-tests {});
+    };
+  };
+in with hps; {
+    inherit selda selda-postgresql selda-tests selda-sqlite;
+  }

--- a/selda-postgresql/default.nix
+++ b/selda-postgresql/default.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, base, bytestring, exceptions, postgresql-libpq
+, selda, stdenv, text
+}:
+mkDerivation {
+  pname = "selda-postgresql";
+  version = "0.1.0.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    base bytestring exceptions postgresql-libpq selda text
+  ];
+  homepage = "https://github.com/valderman/selda";
+  description = "PostgreSQL backend for the Selda database EDSL";
+  license = stdenv.lib.licenses.mit;
+}

--- a/selda-sqlite/default.nix
+++ b/selda-sqlite/default.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, base, direct-sqlite, exceptions, selda, stdenv
+, text
+}:
+mkDerivation {
+  pname = "selda-sqlite";
+  version = "0.1.0.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    base direct-sqlite exceptions selda text
+  ];
+  homepage = "https://github.com/valderman/selda";
+  description = "SQLite backend for the Selda database EDSL";
+  license = stdenv.lib.licenses.mit;
+}

--- a/selda-tests/default.nix
+++ b/selda-tests/default.nix
@@ -1,0 +1,13 @@
+{ mkDerivation, base, directory, exceptions, HUnit, selda
+, selda-sqlite, stdenv, text, time
+}:
+mkDerivation {
+  pname = "selda-tests";
+  version = "0.1.0.0";
+  src = ./.;
+  testHaskellDepends = [
+    base directory exceptions HUnit selda selda-sqlite text time
+  ];
+  description = "Tests for the Selda database DSL";
+  license = stdenv.lib.licenses.mit;
+}

--- a/selda/default.nix
+++ b/selda/default.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, base, exceptions, hashable, mtl, psqueues, stdenv
+, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "selda";
+  version = "0.1.0.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    base exceptions hashable mtl psqueues text time
+    unordered-containers
+  ];
+  homepage = "https://github.com/valderman/selda";
+  description = "Type-safe, high-level EDSL for interacting with relational databases";
+  license = stdenv.lib.licenses.mit;
+}


### PR DESCRIPTION
Nix is great for building multiple Haskell packages. These additions can live alongside the existing `Makefile` and CI system. Simply call `nix-build`, and all packages will be built, tested and haddock'd. If you'd like to use nix for uploading to `hackage` that's possible too (or for testing multiple GHCs on TravisCI).

To build with a different GHC: `nix-build --argstr compiler ghc7103`

```shell
λ nixos selda → λ git nixify → nix-build
/nix/store/ngs0ksf6vvip04h69msiggdxqm6sa0wm-selda-0.1.0.0
/nix/store/nc0fvzqn88mljrd3zlb2awnd1yvzl5kb-selda-postgresql-0.1.0.0
/nix/store/s4nkgphjgmy9wfy56p25055ln5xkriz6-selda-sqlite-0.1.0.0
/nix/store/y6g2vv7cbvwz9yipa07l59mw38vbkzjd-selda-tests-0.1.0.0
```
If you want to develop your `selda` packages in an isolated shell,
```nix-shell -A selda.env``` 

Can also adjust linker settings, flags, if you'd like.