### PR TITLE
Loosen the version constraint on the time package

### DIFF
--- a/selda/selda.cabal
+++ b/selda/selda.cabal
@@ -83,7 +83,7 @@ library
     , exceptions >=0.8 && <0.9
     , mtl        >=2.0 && <2.3
     , text       >=1.0 && <1.3
-    , time       >=1.6 && <1.9
+    , time       >=1.5 && <1.9
   if impl(ghc < 7.11)
     build-depends:
       transformers  >=0.4 && <0.6


### PR DESCRIPTION
This is needed to allow installation with Stack's lts-6.31, which is the latest release that comes with ghc 7.10.3.

That LTS release comes with an older version of the time package (1.5.1.0). Selda compiles just fine with that version, so I suppose it would work just as well.