### PR TITLE
Add an `Ord` instance for `RowID`.

### DIFF
--- a/selda/src/Database/Selda/SqlType.hs
+++ b/selda/src/Database/Selda/SqlType.hs
@@ -128,7 +128,7 @@ instance Show (Lit a) where
 -- | A row identifier for some table.
 --   This is the type of auto-incrementing primary keys.
 newtype RowID = RowID Int
-  deriving (Eq, Typeable)
+  deriving (Eq, Ord, Typeable)
 instance Show RowID where
   show (RowID n) = show n
 


### PR DESCRIPTION
This would be pretty handy for me, since I want to pull some `RowID`s out of some query results and put them into `Set`s and `Map`s.

Feel free to close this if you don't want the instance, or if there are reasons why this would be bad.