### PR TITLE
Add support for json/jsonb column types with PostgreSQL backend

### DIFF
--- a/selda-postgresql/selda-postgresql.cabal
+++ b/selda-postgresql/selda-postgresql.cabal
@@ -32,6 +32,7 @@ library
     , exceptions       >=0.8     && <0.9
     , selda            >=0.1.8.0 && <0.2
     , text             >=1.0     && <1.3
+    , aeson
   if !flag(haste)
     build-depends:
         bytestring       >=0.9 && <0.11

--- a/selda-postgresql/src/Database/Selda/PostgreSQL.hs
+++ b/selda-postgresql/src/Database/Selda/PostgreSQL.hs
@@ -32,7 +32,7 @@ data PGConnectInfo = PGConnectInfo
   , pgUsername :: Maybe T.Text
     -- | Password for authentication, if necessary.
   , pgPassword :: Maybe T.Text
-  }
+  } deriving (Show)
 
 -- | Connect to the given database on the given host, on the default PostgreSQL
 --   port (5432):

--- a/selda/selda.cabal
+++ b/selda/selda.cabal
@@ -7,7 +7,7 @@ description:         This package provides an EDSL for writing portable, type-sa
                      support.
 
                      See the package readme for a brief usage tutorial.
-                     
+
                      To use this package you need at least one backend package, in addition to
                      this package. There are currently two different backend packages:
                      selda-sqlite and selda-postgresql.
@@ -90,6 +90,7 @@ library
     , text                 >=1.0   && <1.3
     , time                 >=1.5   && <1.9
     , unordered-containers >=0.2.6 && <0.3
+    , aeson
   if impl(ghc < 7.11)
     build-depends:
       transformers  >=0.4 && <0.6

--- a/selda/src/Database/Selda/SQL/Print/Config.hs
+++ b/selda/src/Database/Selda/SQL/Print/Config.hs
@@ -13,7 +13,7 @@ data PPConfig = PPConfig
     -- | Parameter placeholder for the @n@th parameter.
   , ppPlaceholder :: Int -> Text
 
-    -- | List of column attributes, such as 
+    -- | List of column attributes, such as
   , ppColAttrs :: [ColAttr] -> Text
 
     -- | The value used for the next value for an auto-incrementing column.
@@ -42,6 +42,7 @@ defType TDateTime = "DATETIME"
 defType TDate     = "DATE"
 defType TTime     = "TIME"
 defType TBlob     = "BLOB"
+defType TJsonb     = "JSONB"
 
 -- | Default compilation for a column attribute.
 defColAttr :: ColAttr -> Text


### PR DESCRIPTION
This is a pretty rough version (I've even used `fromJust` somewhere) that I wrote because I needed it myself.(Caveat: I know little about Postgres, or, indeed, SQL.) Suggestions appreciated for:

1. Version bounds for `aeson`
2. What to do about `json` vs. `jsonb` (I'm using `jsonb` as the representation for Aeson `Value`s, since the Postgres manual seems to recommend it for essentially all cases) -- should `json` even be included at all?
3. Whether I'm doing OIDs wrong -- I just grabbed them from the `libpq` sources and barely know what they are
4. Should there also be SQLite support using `json1`?
5. Postgres apparently supports lots of operations on the JSON values (e.g. field access) in queries. Right now, I think the only interface supported is getting whole `Value`s out and operating on them.

Also, I haven't added tests yet.