### PR TITLE
added a dirty fix for postgres primary key when using generics

### DIFF
--- a/selda-postgresql/src/Database/Selda/PostgreSQL.hs
+++ b/selda-postgresql/src/Database/Selda/PostgreSQL.hs
@@ -131,7 +131,7 @@ pgBackend c = SeldaBackend
   , ppConfig        = defPPConfig
     { ppType = pgColType defPPConfig
     , ppAutoIncInsert = "DEFAULT"
-    , ppColAttrs = ppColAttrs defPPConfig . filter (/= AutoIncrement)
+    , ppColAttrs = T.unwords . map pgColAttr
     }
   , closeConnection = \_ -> finish c
   }
@@ -229,4 +229,12 @@ pgColType _ TFloat    = "FLOAT8"
 pgColType _ TDateTime = "TIMESTAMP"
 pgColType _ TBlob     = "BYTEA"
 pgColType cfg t       = ppType cfg t
+
+-- | Custom compilation for a postgres column attribute.
+pgColAttr :: ColAttr -> T.Text
+pgColAttr Primary       = "PRIMARY KEY"
+pgColAttr AutoIncrement = "SERIAL"
+pgColAttr Required      = "NOT NULL"
+pgColAttr Optional      = "NULL"
+pgColAttr Unique        = "UNIQUE"
 #endif


### PR DESCRIPTION
This should resolve #58 for the time being, but I think `ppType` and `ppColAttrs` should be reworked a bit to allow for passing in type and column attributes to both functions so that this edge cases can be handled properly for all backends.

Alternatively, since `SERIAL` is just an alias for `colname integer NOT NULL DEFAULT nextval('tablename_colname_seq')` we could render `AutoIncrement` as `DEFAULT nextval('tablename_colname_seq')` but than we'd have to pass in table name and column name as well.