### PR TITLE
Added a hook in to PPConfig to allow for more flexibility when generating fields.

### DIFF
--- a/selda/src/Database/Selda/SQL/Print/Config.hs
+++ b/selda/src/Database/Selda/SQL/Print/Config.hs
@@ -15,6 +15,9 @@ data PPConfig = PPConfig
     --   please use the 'ppTypePK' record instead.
     ppType :: SqlTypeRep -> Text
 
+    -- | Hook that allows you to modify 'ppType' output.
+  , ppTypeHook :: SqlTypeRep -> [ColAttr] -> (SqlTypeRep -> Text) -> Text
+
     -- | The SQL type name of the given type for primary keys uses.
   , ppTypePK :: SqlTypeRep -> Text
 
@@ -23,6 +26,9 @@ data PPConfig = PPConfig
 
     -- | List of column attributes.
   , ppColAttrs :: [ColAttr] -> Text
+
+    -- | Hook that allows you to modify 'ppColAttrs' output.
+  , ppColAttrsHook :: SqlTypeRep -> [ColAttr] -> ([ColAttr] -> Text) -> Text
 
     -- | The value used for the next value for an auto-incrementing column.
     --   For instance, @DEFAULT@ for PostgreSQL, and @NULL@ for SQLite.
@@ -45,9 +51,11 @@ data PPConfig = PPConfig
 defPPConfig :: PPConfig
 defPPConfig = PPConfig
     { ppType = defType
+    , ppTypeHook = \ty _ _ -> defType ty
     , ppTypePK = defType
     , ppPlaceholder = T.cons '$' . T.pack . show
     , ppColAttrs = T.unwords . map defColAttr
+    , ppColAttrsHook = \_ ats _ -> T.unwords $ map defColAttr ats
     , ppAutoIncInsert = "NULL"
     , ppMaxInsertParams = Nothing
     }

--- a/selda/src/Database/Selda/Table/Compile.hs
+++ b/selda/src/Database/Selda/Table/Compile.hs
@@ -10,6 +10,7 @@ import Database.Selda.SQL hiding (params, param)
 import Database.Selda.SQL.Print.Config
 import Database.Selda.SqlType (SqlTypeRep(..))
 import Database.Selda.Types
+import Debug.Trace (traceShowId)
 
 data OnError = Fail | Ignore
   deriving (Eq, Ord, Show)
@@ -44,9 +45,11 @@ compileFK col (Table ftbl _ _, fcol) n = mconcat
 compileTableCol :: PPConfig -> ColInfo -> Text
 compileTableCol cfg ci = Text.unwords
     [ fromColName (colName ci)
-    , ppType' cfg cty <> " " <> ppColAttrs cfg (colAttrs ci)
+    , typeHook <> " " <> colAttrsHook
     ]
   where
+    typeHook = ppTypeHook cfg cty attrs (ppType' cfg)
+    colAttrsHook = ppColAttrsHook cfg cty attrs (ppColAttrs cfg)
     cty = colType ci
     attrs = colAttrs ci
     ppType' 


### PR DESCRIPTION
Since DDL differs from database to database I've added a hook that will take generated field definition and allow for more flexible post processing. It works on raw generated text but it should provide enough flexibility for now until API is reworked a bit more (also it's a bit cleaner than my previous attempt).