### PR TITLE
[WIP] CREATE INDEX sketch

### DIFF
--- a/selda/src/Database/Selda/Generic.hs
+++ b/selda/src/Database/Selda/Generic.hs
@@ -101,9 +101,10 @@ data GenAttr a where
 --   an auto-incrementing primary key.
 genTable :: forall a. Relational a
          => TableName
+         -> [TableIndex]
          -> [GenAttr a]
          -> GenTable a
-genTable tn attrs = genTableFieldMod tn attrs id
+genTable tn indexes attrs = genTableFieldMod tn indexes attrs id
 
 -- | Generate a table from the given table name,
 --   a list of column attributes and a function
@@ -125,10 +126,11 @@ genTable tn attrs = genTableFieldMod tn attrs id
 --   "Id", "Name", "Age" and "Pet".
 genTableFieldMod :: forall a. Relational a
                  => TableName
+                 -> [TableIndex]
                  -> [GenAttr a]
                  -> (String -> String)
                  -> GenTable a
-genTableFieldMod tn attrs fieldMod = GenTable $ Table tn (validate tn (map tidy cols)) apk
+genTableFieldMod tn indexes attrs fieldMod = GenTable $ Table tn (validate tn (map tidy cols)) indexes apk
   where
     dummy = mkDummy
     cols = zipWith addAttrs [0..] (tblCols (Proxy :: Proxy a) fieldMod)
@@ -235,8 +237,8 @@ uniqueGen = Attribute [Unique]
 
 -- | A foreign key constraint referencing the given table and column.
 fkGen :: Table t -> Selector t a -> Attribute
-fkGen (Table tn tcs tapk) (Selector i) =
-  ForeignKey (Table tn tcs tapk, colName (tcs !! i))
+fkGen (Table tn tcs indexes tapk) (Selector i) =
+  ForeignKey (Table tn tcs indexes tapk, colName (tcs !! i))
 
 -- | A dummy of some type. Encapsulated to avoid improper use, since all of
 --   its fields are 'unsafeCoerce'd ints.

--- a/selda/src/Database/Selda/Query.hs
+++ b/selda/src/Database/Selda/Query.hs
@@ -18,7 +18,7 @@ import Unsafe.Coerce
 -- | Query the given table. Result is returned as an inductive tuple, i.e.
 --   @first :*: second :*: third <- query tableOfThree@.
 select :: Columns (Cols s a) => Table a -> Query s (Cols s a)
-select (Table name cs _) = Query $ do
+select (Table name cs _ _) = Query $ do
     rns <- mapM (rename . Some . Col) cs'
     st <- get
     put $ st {sources = sqlFrom rns (TableName name) : sources st}

--- a/selda/src/Database/Selda/Selectors.hs
+++ b/selda/src/Database/Selda/Selectors.hs
@@ -87,9 +87,10 @@ instance {-# OVERLAPPABLE #-} (Selectors t a ~ Selector t a) =>
 -- > q = tblBaz <$> select tbl
 tableWithSelectors :: forall a. (TableSpec a, HasSelectors a a)
                    => TableName
+                   -> [TableIndex]
                    -> ColSpecs a
                    -> (Table a, Selectors a a)
-tableWithSelectors name cs = (t, s)
+tableWithSelectors name indexes cs = (t, s)
   where
-    t = table name cs
+    t = table name indexes cs
     s = selectors t

--- a/selda/src/Database/Selda/Table/Compile.hs
+++ b/selda/src/Database/Selda/Table/Compile.hs
@@ -35,7 +35,7 @@ compileCreateTable customColType ifex tbl = ensureValid `seq` mconcat
 
 -- | Compile a foreign key constraint.
 compileFK :: ColName -> (Table (), ColName) -> Int -> Text
-compileFK col (Table ftbl _ _, fcol) n = mconcat
+compileFK col (Table ftbl _ _ _, fcol) n = mconcat
   [ "CONSTRAINT ", fkName, " FOREIGN KEY (", fromColName col, ") "
   , "REFERENCES ", fromTableName ftbl, "(", fromColName fcol, ")"
   ]

--- a/selda/src/Database/Selda/Table/Foreign.hs
+++ b/selda/src/Database/Selda/Table/Foreign.hs
@@ -14,7 +14,7 @@ fk :: ColSpec a -> (Table t, Selector t a) -> ColSpec a
 fk (ColSpec [c]) (tbl, Selector i) =
     ColSpec [c {colFKs = thefk : colFKs c}]
   where
-    Table _ tcs _ = tbl
+    Table _ tcs _ _ = tbl
     thefk = (unsafeCoerce tbl, colName (tcs !! i))
 fk _ _ =
   error "impossible: ColSpec with several columns"
@@ -24,7 +24,7 @@ optFk :: ColSpec (Maybe a) -> (Table t, Selector t a) -> ColSpec (Maybe a)
 optFk (ColSpec [c]) (tbl, Selector i) =
     ColSpec [c {colFKs = thefk : colFKs c}]
   where
-    Table _ tcs _ = tbl
+    Table _ tcs _ _ = tbl
     thefk = (unsafeCoerce tbl, colName (tcs !! i))
 optFk _ _ =
   error "impossible: ColSpec with several columns"

--- a/selda/src/Database/Selda/Types.hs
+++ b/selda/src/Database/Selda/Types.hs
@@ -7,7 +7,7 @@
 module Database.Selda.Types
   ( (:*:)(..), Head, Append (..), (:++:), ToDyn (..), Tup (..)
   , first, second, third, fourth, fifth, sixth, seventh, eighth, ninth, tenth
-  , ColName, TableName
+  , ColName, IndexName, IndexMethod, TableName
   , mkColName, mkTableName, addColSuffix, addColPrefix
   , fromColName, fromTableName
   ) where
@@ -27,6 +27,12 @@ instance Hashable TableName where
 -- | Name of a database column.
 newtype ColName = ColName Text
   deriving (Ord, Eq, Show, IsString)
+
+-- | Name of a database index.
+newtype IndexName = IndexName Text
+  deriving (Ord, Eq, Show, IsString)
+
+data IndexMethod = IndexBTree | IndexHash | IndexGist | IndexGin
 
 -- | Name of a database table.
 newtype TableName = TableName Text


### PR DESCRIPTION
This is just a quick sketch for adding `CREATE INDEX` support to `selda`. I'm keeping it simple so far and haven't put much thought about the design, but the general idea is that indexes are always part of a `Table` and are specified alongside with the rest of the columns.

`validate` can check whether the specified indexes reference valid column names. Everything else should be pretty straightforward if I'm not missing anything.

Both Postgres and SQLite support `CREATE INDEX`, alghouth SQLite doesn't have index methods, like `btree`, `hash` and so on, afaics. I'd still leave `IndexMethod` in though, as this wouldn't negatively impact the SQLite backend.