### PR TITLE
Add SqlOrd instance for RowID

### DIFF
--- a/selda/src/Database/Selda.hs
+++ b/selda/src/Database/Selda.hs
@@ -148,6 +148,7 @@ import Unsafe.Coerce
 -- | Any column type that can be used with the 'min_' and 'max_' functions.
 class SqlType a => SqlOrd a
 instance {-# OVERLAPPABLE #-} (SqlType a, Num a) => SqlOrd a
+instance SqlOrd RowID
 instance SqlOrd Text
 instance SqlOrd Day
 instance SqlOrd UTCTime


### PR DESCRIPTION
allows using min_ and max_ with autoincrementing primary keys. this seems more reasonable than adding a Num instance since doing arithmetic with ids is nonsensical