### PR TITLE
Add nullary function support

### DIFF
--- a/selda/src/Database/Selda.hs
+++ b/selda/src/Database/Selda.hs
@@ -76,7 +76,8 @@ module Database.Selda
   , (:*:)(..)
   , select, selectValues, from, distinct
   , restrict, limit
-  , order , ascending, descending
+  , order, ascending, descending
+  , orderRandom
   , inner, suchThat
     -- * Expressions over columns
   , Set (..)

--- a/selda/src/Database/Selda/Column.hs
+++ b/selda/src/Database/Selda/Column.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE GADTs, TypeFamilies, TypeOperators, PolyKinds, FlexibleInstances #-}
+{-# LANGUAGE GADTs, TypeFamilies, TypeOperators, PolyKinds, FlexibleInstances, OverloadedStrings #-}
 -- | Columns and associated utility functions, specialized to 'SQL'.
 module Database.Selda.Column
   ( Cols, Columns
-  , Col (..), SomeCol (..), Exp (..), UnOp (..), BinOp (..)
+  , Col (..), SomeCol (..), Exp (..), NulOp (..), UnOp (..), BinOp (..)
   , toTup, fromTup, liftC, liftC2, liftC3
   , allNamesIn
   , literal

--- a/selda/src/Database/Selda/Exp.hs
+++ b/selda/src/Database/Selda/Exp.hs
@@ -19,12 +19,16 @@ data Exp sql a where
   Lit     :: !(Lit a) -> Exp sql a
   BinOp   :: !(BinOp a b) -> !(Exp sql a) -> !(Exp sql a) -> Exp sql b
   UnOp    :: !(UnOp a b) -> !(Exp sql a) -> Exp sql b
+  NulOp   :: !(NulOp a) -> Exp sql a
   Fun2    :: !Text -> !(Exp sql a) -> !(Exp sql b) -> Exp sql c
   If      :: !(Exp sql Bool) -> !(Exp sql a) -> !(Exp sql a) -> Exp sql a
   Cast    :: !SqlTypeRep -> !(Exp sql a) -> Exp sql b
   AggrEx  :: !Text -> !(Exp sql a) -> Exp sql b
   InList  :: !(Exp sql a) -> ![Exp sql a] -> Exp sql Bool
   InQuery :: !(Exp sql a) -> !sql -> Exp sql Bool
+
+data NulOp a where
+  Fun0   :: Text -> NulOp a
 
 data UnOp a b where
   Abs    :: UnOp a a
@@ -63,6 +67,7 @@ instance Names sql => Names (Exp sql a) where
   allNamesIn (Lit _)       = []
   allNamesIn (BinOp _ a b) = allNamesIn a ++ allNamesIn b
   allNamesIn (UnOp _ a)    = allNamesIn a
+  allNamesIn (NulOp _)     = []
   allNamesIn (Fun2 _ a b)  = allNamesIn a ++ allNamesIn b
   allNamesIn (If a b c)    = allNamesIn a ++ allNamesIn b ++ allNamesIn c
   allNamesIn (Cast _ x)    = allNamesIn x

--- a/selda/src/Database/Selda/Query.hs
+++ b/selda/src/Database/Selda/Query.hs
@@ -2,7 +2,7 @@
 -- | Query monad and primitive operations.
 module Database.Selda.Query
   ( select, selectValues, Database.Selda.Query.distinct
-  , restrict, groupBy, limit, order
+  , restrict, groupBy, limit, order, orderRandom
   , aggregate, leftJoin, innerJoin
   ) where
 import Data.Maybe (isNothing)
@@ -214,6 +214,10 @@ order (C c) o = Query $ do
     [sql] -> put st {sources = [sql {ordering = (o, Some c) : ordering sql}]}
     ss    -> put st {sources = [sql {ordering = [(o,Some c)]}]}
       where sql = sqlFrom (allCols ss) (Product ss)
+
+-- | Sort the result rows in random order.
+orderRandom :: Query s ()
+orderRandom = order (C (NulOp (Fun0 "RANDOM"))) Asc
 
 -- | Remove all duplicates from the result set.
 distinct :: Query s a -> Query s a

--- a/selda/src/Database/Selda/SQL/Print.hs
+++ b/selda/src/Database/Selda/SQL/Print.hs
@@ -223,6 +223,7 @@ ppCol (Col name)     = pure (fromColName name)
 ppCol (Lit l)        = ppLit l
 ppCol (BinOp op a b) = ppBinOp op a b
 ppCol (UnOp op a)    = ppUnOp op a
+ppCol (NulOp a)      = ppNulOp a
 ppCol (Fun2 f a b)   = do
   a' <- ppCol a
   b' <- ppCol b
@@ -245,6 +246,9 @@ ppCol (InQuery x q) = do
   x' <- ppCol x
   q' <- ppSql q
   pure $ mconcat [x', " IN (", q', ")"]
+
+ppNulOp :: NulOp a -> PP Text
+ppNulOp (Fun0 f) = pure $ f <> "()"
 
 ppUnOp :: UnOp a b -> Exp SQL a -> PP Text
 ppUnOp op c = do

--- a/selda/src/Database/Selda/Unsafe.hs
+++ b/selda/src/Database/Selda/Unsafe.hs
@@ -33,3 +33,7 @@ fun f = liftC $ UnOp (Fun f)
 -- | Like 'fun', but with two arguments.
 fun2 :: Text -> Col s a -> Col s b -> Col s c
 fun2 f = liftC2 (Fun2 f)
+
+-- | Like 'fun', but with zero arguments.
+fun0 :: Text -> Col s a
+fun0 f = C $ NulOp (Fun0 f)


### PR DESCRIPTION
this may be less than ideal, I don't really like exporting `random` as a simple column because its use is more restricted than that, and it can't be given a concrete type here since `random()`'s return type differs between postgres (double) and sqlite (64-bit int). usecase is to be able to do `order random ascending`