### PR TITLE
Allow multiple primary keys - continued

### DIFF
--- a/selda-postgresql/src/Database/Selda/PostgreSQL.hs
+++ b/selda-postgresql/src/Database/Selda/PostgreSQL.hs
@@ -235,7 +235,7 @@ pgGetTableInfo c tbl = do
     Right (_, vals) <- pgQueryRunner c False tableinfo []
     if null vals
       then do
-        pure $ TableInfo [] []
+        pure $ TableInfo [] [] []
       else do
         Right pkInfo <- pgQueryRunner c False pkquery []
         let pk = case pkInfo of
@@ -310,9 +310,7 @@ pgGetTableInfo c tbl = do
       return $ ColumnInfo
         { colName = mkColName name
         , colType = mkTypeRep (pk == Just name) ty'
-        , colIsPK = pk == Just name
         , colIsAutoIncrement = ty' == "bigserial"
-        , colIsUnique = name `elem` us
         , colIsNullable = readBool (encodeUtf8 (T.toLower nullable))
         , colHasIndex = name `elem` ixs
         , colFKs =

--- a/selda-sqlite/src/Database/Selda/SQLite.hs
+++ b/selda-sqlite/src/Database/Selda/SQLite.hs
@@ -78,6 +78,7 @@ sqliteGetTableInfo db tbl = do
         [ map mkColName names
         | (names@(_:_:_), "u") <- indexes'
         ]
+      , tablePkGroups = [] -- not sure what to put here
       }
   where
     tblinfo = mconcat ["PRAGMA table_info(", tbl, ");"]
@@ -109,10 +110,8 @@ sqliteGetTableInfo db tbl = do
       return $ ColumnInfo
         { colName = mkColName name
         , colType = toTypeRep (pk == 1) (toLower ty)
-        , colIsPK = pk == 1
         , colIsAutoIncrement = "auto_increment" `isSuffixOf` ty
         , colHasIndex = isUnique || isMultiUnique || any (== ([name], "c")) ixs
-        , colIsUnique = isUnique
         , colIsNullable = nonnull == 0
         , colFKs =
             [ (mkTableName reftbl, mkColName refkey)

--- a/selda/src/Database/Selda/Table.hs
+++ b/selda/src/Database/Selda/Table.hs
@@ -126,12 +126,21 @@ tableFieldMod tn attrs fieldMod = Table
   { tableName = tn
   , tableCols = map tidy cols
   , tableHasAutoPK = apk
-  , tableAttrs = combinedAttrs
+  , tableAttrs = combinedAttrs ++ pkAttrs
   }
   where
     combinedAttrs =
       [ (ixs, a)
       | sel :- Attribute [a] <- attrs
+      , let ixs = indices sel
+      , case ixs of
+          []  -> False
+          [_] -> False
+          _   -> True
+      ]
+    pkAttrs =
+      [ (ixs, Primary)
+      | sel :- Attribute [Primary,Required,Unique] <- attrs
       , let ixs = indices sel
       , case ixs of
           []  -> False
@@ -168,7 +177,7 @@ data Attribute (g :: * -> * -> *) t c
   | ForeignKey (Table (), ColName)
 
 -- | A primary key which does not auto-increment.
-primary :: Attribute Selector t c
+primary :: SelectorGroup g => Attribute g t a
 primary = Attribute [Primary, Required, Unique]
 
 -- | Create an index on this column.

--- a/selda/src/Database/Selda/Table.hs
+++ b/selda/src/Database/Selda/Table.hs
@@ -139,7 +139,7 @@ tableFieldMod tn attrs fieldMod = Table
           _   -> True
       ]
     pkAttrs =
-      [ (ixs, Primary)
+      concat [ [(ixs, Primary), (ixs, Required), (ixs, Unique)]
       | sel :- Attribute [Primary,Required,Unique] <- attrs
       , let ixs = indices sel
       , case ixs of

--- a/selda/src/Database/Selda/Table/Compile.hs
+++ b/selda/src/Database/Selda/Table/Compile.hs
@@ -25,11 +25,15 @@ compileCreateTable cfg ifex tbl =
   where
     createTable = mconcat
       [ "CREATE TABLE ", ifNotExists ifex, fromTableName (tableName tbl), "("
-      , intercalate ", " (map (compileTableCol cfg) (tableCols tbl) ++ multiUniques)
+      , intercalate ", " (map (compileTableCol cfg) (tableCols tbl) ++ multiUniques ++ multiPrimary)
       , case allFKs of
           [] -> ""
           _  -> ", " <> intercalate ", " compFKs
       , ")"
+      ]
+    multiPrimary =
+      [ mconcat ["PRIMARY KEY(", intercalate ", " (colNames ixs), ")"]
+      | (ixs, Primary) <- tableAttrs tbl
       ]
     multiUniques =
       [ mconcat ["UNIQUE(", intercalate ", " (colNames ixs), ")"]

--- a/selda/src/Database/Selda/Validation.hs
+++ b/selda/src/Database/Selda/Validation.hs
@@ -205,10 +205,8 @@ diffColumns inschema indb =
              Just (TypeMismatch schemaColType t)
            _ ->
              Nothing
-       , check colIsPK PrimaryKeyMismatch
        , check colIsAutoIncrement AutoIncrementMismatch
        , check colIsNullable NullableMismatch
-       , check colIsUnique UniqueMismatch
        , check colHasIndex IndexMismatch
        ] ++ mconcat
        [ map (Just . uncurry ForeignKeyPresent)


### PR DESCRIPTION
continuation from #111

Not sure how to "make sure the validation and migration machinery takes TableInfo.tablePkGroups into account."

