### PR TITLE
fix issue where tableUniqueGroups would always come back as []

### DIFF
--- a/selda-postgresql/src/Database/Selda/PostgreSQL.hs
+++ b/selda-postgresql/src/Database/Selda/PostgreSQL.hs
@@ -242,7 +242,6 @@ pgGetTableInfo c tbl = do
         Right (_, pkInfo) <- pgQueryRunner c False pkquery []
         Right (_, us) <- pgQueryRunner c False uniquequery []
         let uniques = map splitNames us
-            loneUniques = [u | [u] <- uniques]
         Right (_, fks) <- pgQueryRunner c False fkquery []
         Right (_, ixs) <- pgQueryRunner c False ixquery []
         colInfos <- mapM (describe fks (map toText ixs)) vals

--- a/selda-postgresql/src/Database/Selda/PostgreSQL.hs
+++ b/selda-postgresql/src/Database/Selda/PostgreSQL.hs
@@ -248,10 +248,7 @@ pgGetTableInfo c tbl = do
         colInfos <- mapM (describe fks (map toText ixs)) vals
         x <- pure $ TableInfo
           { tableColumnInfos = colInfos
-          , tableUniqueGroups =
-            [ map mkColName names
-            | names@(_:_:_) <- uniques
-            ]
+          , tableUniqueGroups = map (map mkColName) uniques
           , tablePrimaryKey = [mkColName pk | [SqlString pk] <- pkInfo]
           }
         pure x


### PR DESCRIPTION
Currently tableUniqueGroups (from the database) always comes back with an empty list.
The type of tableUniqueGroups has changed making the list comprehension fail.

The code looked significantly different for SQLite and I didn't have a look at if it was broken there too.