### PR TITLE
Add multicolumn index support.

### DIFF
--- a/ChangeLog.hs
+++ b/ChangeLog.hs
@@ -10,7 +10,10 @@ import Text.Read
 
 changeLog :: ChangeLog
 changeLog =
-  [ Version "0.4.1.0" "TBD"
+  [ Version "0.5.0.0" "2019-08-05"
+    "Multi-column support"
+    ["index and indexUsing now accept a Group instead of a Selector"]
+  , Version "0.4.1.0" "2019-06-30"
     "Better type errors and generic row identifiers"
     [ "Custom type errors for scope mismatches."
     , "Provide Generic instances for ID and RowID."

--- a/selda-json/selda-json.cabal
+++ b/selda-json/selda-json.cabal
@@ -21,7 +21,7 @@ library
       aeson      >=1.0  && <1.5
     , base       >=4.9  && <5
     , bytestring >=0.10 && <0.11
-    , selda      >=0.4  && <0.5
+    , selda      >=0.4  && <0.6
     , text       >=1.0  && <1.3
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/selda-postgresql/selda-postgresql.cabal
+++ b/selda-postgresql/selda-postgresql.cabal
@@ -31,7 +31,7 @@ library
       base       >=4.9 && <5
     , bytestring >=0.9 && <0.11
     , exceptions >=0.8 && <0.11
-    , selda      >=0.4 && <0.5
+    , selda      >=0.4 && <0.6
     , selda-json >=0.1 && <0.2
     , text       >=1.0 && <1.3
   if !flag(haste)

--- a/selda-sqlite/selda-sqlite.cabal
+++ b/selda-sqlite/selda-sqlite.cabal
@@ -26,7 +26,7 @@ library
     CPP
   build-depends:
       base          >=4.9 && <5
-    , selda         >=0.4 && <0.5
+    , selda         >=0.4 && <0.6
     , text          >=1.0 && <1.3
   if !flag(haste)
     build-depends:

--- a/selda-tests/test/Tables.hs
+++ b/selda-tests/test/Tables.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings, TypeOperators, DeriveGeneric, CPP #-}
 #if MIN_VERSION_base(4, 9, 0)
-{-# LANGUAGE OverloadedLabels, FlexibleContexts, DataKinds #-}
+{-# LANGUAGE OverloadedLabels, FlexibleContexts, DataKinds, MonoLocalBinds #-}
 #endif
 -- | Tables for reuse by most tests, and functions for their setup and teardown.
 module Tables where
@@ -25,9 +25,11 @@ modPeople = tableFieldMod "modpeople" [Single pName :- primary] $ \name ->
 people :: Table Person
 people = table "people"
   [ Single pName :- primary
-  , pName :- index
-  , pCash :- indexUsing HashIndex
+  , Single pName :- index
+  , Single pCash :- indexUsing HashIndex
+  , pName :+ Single pCash :- index
   ]
+
 pName = #name :: Selector Person Text
 pAge :: HasField "age" t => Selector t (FieldType "age" t)
 pAge  = #age

--- a/selda-tests/test/Tests/Mutable.hs
+++ b/selda-tests/test/Tests/Mutable.hs
@@ -815,7 +815,7 @@ migrateIndex = do
     dropTable tbl1
   where
     tbl1 :: Table (Only Int)
-    (tbl1, a1) = tableWithSelectors "foo" [a1 :- index]
+    (tbl1, a1) = tableWithSelectors "foo" [Single a1 :- index]
 
     tbl2 :: Table (Int, Int)
-    (tbl2, a2 :*: b) = tableWithSelectors "foo" [a2 :- index]
+    (tbl2, a2 :*: b) = tableWithSelectors "foo" [Single a2 :- index]

--- a/selda-tests/test/Tests/Validation.hs
+++ b/selda-tests/test/Tests/Validation.hs
@@ -154,59 +154,59 @@ validateWrongTable = do
   where
     goodPeople :: Table (Text, Int, Maybe Text, Double)
     goodPeople = table "people"
-      [ (unsafeSelector 0 :: Selector (Text, Int, Maybe Text, Double) Text)
+      [ (Single (unsafeSelector 0 :: Selector (Text, Int, Maybe Text, Double) Text))
           :- index
-      , (unsafeSelector 3 :: Selector (Text, Int, Maybe Text, Double) Double)
+      , (Single (unsafeSelector 3 :: Selector (Text, Int, Maybe Text, Double) Double))
           :- indexUsing HashIndex
       ]
 
     badPeople1 :: Table (Text, Int, Text, Double)
     badPeople1 = table "people"
-      [ (unsafeSelector 0 :: Selector (Text, Int, Text, Double) Text)
+      [ (Single (unsafeSelector 0 :: Selector (Text, Int, Text, Double) Text))
           :- index
-      , (unsafeSelector 3 :: Selector (Text, Int, Text, Double) Double)
+      , (Single (unsafeSelector 3 :: Selector (Text, Int, Text, Double) Double))
           :- indexUsing HashIndex
       ]
 
     badPeople2 :: Table (Text, Bool, Maybe Text, Double)
     badPeople2 = table "people"
-      [ (unsafeSelector 0 :: Selector (Text, Bool, Maybe Text, Double) Text) :- index
-      , (unsafeSelector 3 :: Selector (Text, Bool, Maybe Text, Double) Double) :- indexUsing HashIndex
+      [ (Single (unsafeSelector 0 :: Selector (Text, Bool, Maybe Text, Double) Text)) :- index
+      , (Single (unsafeSelector 3 :: Selector (Text, Bool, Maybe Text, Double) Double)) :- indexUsing HashIndex
       ]
 
     badPeople3 :: Table (Text, Int, Maybe Text)
     badPeople3 = table "people"
-      [ (unsafeSelector 0 :: Selector (Text, Int, Maybe Text) Text) :- index
+      [ (Single (unsafeSelector 0 :: Selector (Text, Int, Maybe Text) Text)) :- index
       ]
 
     badPeople4 :: Table (Text, Int, Maybe Text, Double, Int)
     badPeople4 = table "people"
-      [ (unsafeSelector 0 :: Selector (Text, Int, Maybe Text, Double, Int) Text) :- index
-      , (unsafeSelector 3 :: Selector (Text, Int, Maybe Text, Double, Int) Double) :- indexUsing HashIndex
+      [ (Single (unsafeSelector 0 :: Selector (Text, Int, Maybe Text, Double, Int) Text)) :- index
+      , (Single (unsafeSelector 3 :: Selector (Text, Int, Maybe Text, Double, Int) Double)) :- indexUsing HashIndex
       ]
 
     badIxPeople1 :: Table (Text, Int, Maybe Text, Double)
     badIxPeople1 = table "people"
-      [ (unsafeSelector 3 :: Selector (Text, Int, Maybe Text, Double) Double) :- indexUsing HashIndex
+      [ (Single (unsafeSelector 3 :: Selector (Text, Int, Maybe Text, Double) Double)) :- indexUsing HashIndex
       ]
 
     badIxPeople2 :: Table (Text, Int, Maybe Text, Double)
     badIxPeople2 = table "people"
-      [ (unsafeSelector 2 :: Selector (Text, Int, Maybe Text, Double) (Maybe Text)) :- index
+      [ (Single (unsafeSelector 2 :: Selector (Text, Int, Maybe Text, Double) (Maybe Text))) :- index
       ]
 
     badIxPeople3 :: Table (Text, Int, Maybe Text, Double)
     badIxPeople3 = table "people"
-      [ (unsafeSelector 0 :: Selector (Text, Int, Maybe Text, Double) Text) :- index
-      , (unsafeSelector 2 :: Selector (Text, Int, Maybe Text, Double) (Maybe Text)) :- index
-      , (unsafeSelector 3 :: Selector (Text, Int, Maybe Text, Double) Double) :- indexUsing HashIndex
+      [ (Single (unsafeSelector 0 :: Selector (Text, Int, Maybe Text, Double) Text)) :- index
+      , (Single (unsafeSelector 2 :: Selector (Text, Int, Maybe Text, Double) (Maybe Text))) :- index
+      , (Single (unsafeSelector 3 :: Selector (Text, Int, Maybe Text, Double) Double)) :- indexUsing HashIndex
       ]
 
     badIxPeople4 :: Table (Text, Int, Maybe Text, Double)
     badIxPeople4 = table "people"
-      [ (unsafeSelector 1 :: Selector (Text, Int, Maybe Text, Double) Int) :- index
-      , (unsafeSelector 2 :: Selector (Text, Int, Maybe Text, Double) (Maybe Text)) :- indexUsing HashIndex
-      , (unsafeSelector 3 :: Selector (Text, Int, Maybe Text, Double) Double) :- indexUsing HashIndex
+      [ (Single (unsafeSelector 1 :: Selector (Text, Int, Maybe Text, Double) Int)) :- index
+      , (Single (unsafeSelector 2 :: Selector (Text, Int, Maybe Text, Double) (Maybe Text))) :- indexUsing HashIndex
+      , (Single (unsafeSelector 3 :: Selector (Text, Int, Maybe Text, Double) Double)) :- indexUsing HashIndex
       ]
 
 validateNonexistentTable = do

--- a/selda/selda.cabal
+++ b/selda/selda.cabal
@@ -1,5 +1,5 @@
 name:                selda
-version:             0.4.1.0
+version:             0.5.0.0
 synopsis:            Multi-backend, high-level EDSL for interacting with SQL databases.
 description:         This package provides an EDSL for writing portable, type-safe, high-level
                      database code. Its feature set includes querying and modifying databases,

--- a/selda/src/Database/Selda/Table.hs
+++ b/selda/src/Database/Selda/Table.hs
@@ -15,7 +15,7 @@ module Database.Selda.Table
   , untypedAutoPrimary, weakUntypedAutoPrimary
   , unique
   , index, indexUsing
-  , tableExpr, indexedCols
+  , tableExpr
   , isAutoPrimary, isPrimary, isUnique
   ) where
 import Data.Text (Text)
@@ -122,9 +122,10 @@ tableFieldMod tn attrs fieldMod = Table
       | sel :- Attribute [a] <- attrs
       , let ixs = indices sel
       , case ixs of
-          (_:_:_)           -> True
-          [_] | a == Unique -> True
-          _                 -> False
+          (_:_:_)              -> True
+          [_] | a == Unique    -> True
+          [_] | Indexed _ <- a -> True
+          _                    -> False
       ]
     pkAttrs = concat
       [ [(ixs, Primary), (ixs, Required)]
@@ -173,12 +174,12 @@ data Attribute (g :: * -> * -> *) t c
 primary :: Attribute Group t a
 primary = Attribute [Primary, Required]
 
--- | Create an index on this column.
-index :: Attribute Selector t c
+-- | Create an index on these column(s).
+index :: Attribute Group t c
 index = Attribute [Indexed Nothing]
 
 -- | Create an index using the given index method on this column.
-indexUsing :: IndexMethod -> Attribute Selector t c
+indexUsing :: IndexMethod -> Attribute Group t c
 indexUsing m = Attribute [Indexed (Just m)]
 
 -- | An auto-incrementing primary key.

--- a/selda/src/Database/Selda/Table/Type.hs
+++ b/selda/src/Database/Selda/Table/Type.hs
@@ -23,14 +23,6 @@ data Table a = Table
   , tableAttrs :: [([Int], ColAttr)]
   }
 
--- | Get all table columns with an explicit index.
-indexedCols :: Table a -> [(ColName, Maybe IndexMethod)]
-indexedCols t =
-  [ (colName col, mmethod)
-  | col <- tableCols t
-  , Indexed mmethod <- colAttrs col
-  ]
-
 -- | A complete description of a database column.
 data ColInfo = ColInfo
   { colName  :: ColName

--- a/selda/src/Database/Selda/Types.hs
+++ b/selda/src/Database/Selda/Types.hs
@@ -9,15 +9,15 @@ module Database.Selda.Types
   , first, second, third, fourth, fifth
   , ColName, TableName
   , modColName, mkColName, mkTableName, addColSuffix, addColPrefix
-  , fromColName, fromTableName, rawTableName
+  , fromColName, fromTableName, rawTableName, intercalateColNames
   ) where
 import Data.Dynamic
 import Data.String
-import Data.Text (Text, replace, append)
+import Data.Text (Text, replace, append, intercalate)
 import GHC.Generics (Generic)
 
 -- | Name of a database column.
-newtype ColName = ColName Text
+newtype ColName = ColName { unColName :: Text }
   deriving (Ord, Eq, Show, IsString)
 
 -- | Name of a database table.
@@ -39,6 +39,15 @@ addColSuffix (ColName cn) s = ColName $ Data.Text.append cn s
 -- | Convert a column name into a string, with quotes.
 fromColName :: ColName -> Text
 fromColName (ColName cn) = mconcat ["\"", escapeQuotes cn, "\""]
+
+-- | Convert column names into a string, without quotes, intercalating the given
+-- string.
+--
+-- @
+-- intercalateColNames "_" [ColName "a", ColName "b"] == "a_b"
+-- @
+intercalateColNames :: Text -> [ColName] -> Text
+intercalateColNames inter cs = intercalate inter (escapeQuotes . unColName <$> cs)
 
 -- | Convert a table name into a string, with quotes.
 fromTableName :: TableName -> Text


### PR DESCRIPTION
Indexes used to be generated by looking at the column attributes for an `Indexed` column, which limited the design to a single selector.  The new method stores indexes in the table attributes which are then used by `compileCreateIndex`.

API

The api for indexes has changed from accepting a Selector to a Group. Thus code that used to appear `[col :- index]` might now need to be `[Single col :- index]`.  With the advantage that we can now say `[(Single col2 :+ Single col1) :- index]`.

The version of selda has been bumped in response to this API change.

Uniqueness

Index names are constructed by from the column names, which are recovered by looking up each column info based on index. Any underscores in the column name is escaped ("column_name" ~~> "column__name") and all columns are joined using a single underscore to form the index name.