### PR TITLE
Expose tableName from Table

### DIFF
--- a/selda/src/Database/Selda.hs
+++ b/selda/src/Database/Selda.hs
@@ -25,7 +25,7 @@ module Database.Selda
   , SeldaError (..), ValidationError
   , SeldaT, SeldaM
   , Relational, Only (..), The (..)
-  , Table, Query, Row, Col, Res, Result
+  , Table (tableName), Query, Row, Col, Res, Result
   , query, queryInto
   , transaction, withoutForeignKeyEnforcement
   , newUuid


### PR DESCRIPTION
I find that exposing the table name from the table data type is very convenient and I can't see any downsides with exposing it