### PR TITLE
Add tableInfoName field to TableInfo that holds the TableName from Table

### DIFF
--- a/selda-postgresql/src/Database/Selda/PostgreSQL.hs
+++ b/selda-postgresql/src/Database/Selda/PostgreSQL.hs
@@ -265,7 +265,7 @@ pgGetTableInfo c tbl = do
     Right (_, vals) <- pgQueryRunner c False tableinfo []
     if null vals
       then do
-        pure $ TableInfo [] [] []
+        pure $ TableInfo (mkTableName tbl) [] [] []
       else do
         Right (_, pkInfo) <- pgQueryRunner c False pkquery []
         Right (_, us) <- pgQueryRunner c False uniquequery []
@@ -274,7 +274,8 @@ pgGetTableInfo c tbl = do
         Right (_, ixs) <- pgQueryRunner c False ixquery []
         colInfos <- mapM (describe fks (map toText ixs)) vals
         x <- pure $ TableInfo
-          { tableColumnInfos = colInfos
+          { tableInfoName = mkTableName tbl
+          , tableColumnInfos = colInfos
           , tableUniqueGroups = map (map mkColName) uniques
           , tablePrimaryKey = [mkColName pk | [SqlString pk] <- pkInfo]
           }

--- a/selda-sqlite/src/Database/Selda/SQLite.hs
+++ b/selda-sqlite/src/Database/Selda/SQLite.hs
@@ -91,7 +91,8 @@ sqliteGetTableInfo db tbl = do
     ixs <- mapM indexInfo . snd . snd =<< sqliteQueryRunner db indexes []
     colInfos <- mapM (describe fks ixs cs) cols
     return $ TableInfo
-      { tableColumnInfos = colInfos
+      { tableInfoName = mkTableName tbl
+      , tableColumnInfos = colInfos
       , tableUniqueGroups =
         [ map mkColName names
         | (names, "u") <- ixs

--- a/selda/src/Database/Selda/Backend/Internal.hs
+++ b/selda/src/Database/Selda/Backend/Internal.hs
@@ -126,8 +126,10 @@ allStmts = fmap (map (\(k, v) -> (StmtID k, stmtHandle v)) . M.toList)
 
 -- | Comprehensive information about a table.
 data TableInfo = TableInfo
-  { -- | Ordered information about each table column.
-    tableColumnInfos :: [ColumnInfo]
+  { -- | Name of the table.
+    tableInfoName :: TableName
+    -- | Ordered information about each table column.
+  , tableColumnInfos :: [ColumnInfo]
     -- | Unordered list of all (non-PK) uniqueness constraints on this table.
   , tableUniqueGroups :: [[ColName]]
     -- | Unordered list of all primary key constraints on this table.
@@ -167,7 +169,8 @@ fromColInfo ci = ColumnInfo
 -- | Get the column information for each column in the given table.
 tableInfo :: Table a -> TableInfo
 tableInfo t = TableInfo
-  { tableColumnInfos = map fromColInfo (tableCols t)
+  { tableInfoName = tableName t
+  , tableColumnInfos = map fromColInfo (tableCols t)
   , tableUniqueGroups = uniqueGroups
   , tablePrimaryKey = pkGroup
   }


### PR DESCRIPTION
This adds a field to `TableInfo` for holding the `TableName`.

This fixes https://github.com/valderman/selda/issues/147.

I tested this by running `make test`, but I didn't run the postgresql-specific tests (hopefully this is tested in CI?)