### PR TITLE
Exporting GSqlRow to be able to refer to it

### DIFF
--- a/selda/src/Database/Selda.hs
+++ b/selda/src/Database/Selda.hs
@@ -31,7 +31,7 @@ module Database.Selda
   , newUuid
 
     -- * Constructing queries
-  , SqlType (..), SqlRow (..), SqlEnum (..)
+  , SqlType (..), SqlRow (..), GSqlRow, SqlEnum (..)
   , Columns, Same
   , Order (..)
   , (:*:)(..)

--- a/selda/src/Database/Selda/SqlRow.hs
+++ b/selda/src/Database/Selda/SqlRow.hs
@@ -6,6 +6,7 @@
 #endif
 module Database.Selda.SqlRow
   ( SqlRow (..), ResultReader
+  , GSqlRow
   , runResultReader, next
   ) where
 import Control.Monad.State.Strict


### PR DESCRIPTION
I'm only exporting the class name, not its methods.

That's useful when doing Generic hackery in client libraries. For instance I'm derivating Tables out of vinyl records, and in order to make Rec an instance to SqlRow, I need to refer to `GSqlRow`.