### PR TITLE
Do not isolate `distinct` to avoid missing renames

### DIFF
--- a/selda-postgresql/src/Database/Selda/PostgreSQL/Encoding.hs
+++ b/selda-postgresql/src/Database/Selda/PostgreSQL/Encoding.hs
@@ -19,7 +19,6 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (toLower)
 import qualified Data.Text as T
-import qualified Data.Text.Lazy as LazyText
 import Data.Time (utc, localToUTCTimeOfDay)
 import Database.PostgreSQL.LibPQ (Oid (..), Format (Binary))
 import Database.Selda.Backend

--- a/selda-tests/test/Tests/Query.hs
+++ b/selda-tests/test/Tests/Query.hs
@@ -77,6 +77,7 @@ queryTests run = test
   , "string concatenation" ~: run stringConcatenation
   , "teardown succeeds" ~: run teardown
   , "if not exists works" ~: run (setup >> resetup)
+  , "two distinct clauses works" ~: run twoDistinctClauses
   ]
 
 simpleSelect = do
@@ -694,3 +695,10 @@ unionAllForWholeRows = assQueryEq "wrong person list returned" correct $ do
 
 stringConcatenation = assQueryEq "wrong string returned" ["abcde"] $ do
   pure $ mconcat ["a" :: Col s Text, "bc", "", "de"]
+
+twoDistinctClauses = do
+  res <- query $ aggregate $ do
+      ppl <- distinct $ pName `from` select people
+      _ <- distinct $ pName `from` select people
+      return (count ppl)
+  assEq "distinct people is wrong" [4] res

--- a/selda/src/Database/Selda/Query.hs
+++ b/selda/src/Database/Selda/Query.hs
@@ -259,8 +259,8 @@ distinct :: (Columns a, Columns (OuterCols a))
          => Query (Inner s) a
          -> Query s (OuterCols a)
 distinct q = Query $ do
-  (inner_st, res) <- isolate q
+  res <- unQ q
   st <- get
-  let ss = sources inner_st
+  let ss = sources st
   put st {sources = [(sqlFrom (allCols ss) (Product ss)) {SQL.distinct = True}]}
   return (unsafeCoerce res)


### PR DESCRIPTION
Fix #165 by removing isolate from `distinct` calls.

Recall that queries in the form:

```
borked :: Query s (Col s Int)
borked = aggregate $ do
    _ <- distinct $ do
            t <- select people
            pure (t ! #msg)
    x <- distinct $ do
            t <- select people
            pure (t ! #name)
    pure (count x)
```

Cause Selda + the psql backend to fail.  For a complete program see #165 and a throw-away psql such as `docker run -p 5432:5432 --rm -e POSTGRES_PASSWORD=password -d postgres`.

This query now succeeds along with `make test` and the `make pgtest` target.  That said, I don't claim to have shoved the whole selda design into my head so viewing the PR with some suspicion is warranted.