### PR TITLE
Use "+HH:MM" suffix instead of "+HHMM" when storing datetime's as text

### DIFF
--- a/selda/src/Database/Selda/SqlType.hs
+++ b/selda/src/Database/Selda/SqlType.hs
@@ -28,7 +28,7 @@ import GHC.Generics (Generic)
 --   representing timestamps as text.
 --   If at all possible, use 'SqlUTCTime' instead.
 sqlDateTimeFormat :: String
-sqlDateTimeFormat = "%F %H:%M:%S%Q%z"
+sqlDateTimeFormat = "%F %H:%M:%S%Q%Ez"
 
 -- | Format string used to represent date when
 --   representing dates as text.


### PR DESCRIPTION
This fixes issue with Sqlite date/time functions not working. Sqlite only supports "+HH:MM" suffix with colon, see https://www.sqlite.org/lang_datefunc.html#time_values