### PR TITLE
Enable compatibility with newer GHC and dependency versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ dist
 /*/LICENSE
 dist-newstyle
 cabal.project.local
+.stack-work/
+/stack*.yaml.lock
 *.sqlite
 !.gitignore
 !.github

--- a/selda-json/selda-json.cabal
+++ b/selda-json/selda-json.cabal
@@ -17,9 +17,9 @@ library
   exposed-modules:
     Database.Selda.JSON
   build-depends:
-      aeson      >=1.0  && <1.6
+      aeson      >=1.0  && <2.1
     , base       >=4.9  && <5
-    , bytestring >=0.10 && <0.11
+    , bytestring >=0.10 && <0.12
     , selda      >=0.4  && <0.6
     , text       >=1.0  && <1.3
   hs-source-dirs:      src

--- a/selda-postgresql/selda-postgresql.cabal
+++ b/selda-postgresql/selda-postgresql.cabal
@@ -28,7 +28,7 @@ library
     CPP
   build-depends:
       base       >=4.9 && <5
-    , bytestring >=0.9 && <0.11
+    , bytestring >=0.9 && <0.12
     , exceptions >=0.8 && <0.11
     , selda      >=0.5 && <0.6
     , selda-json >=0.1 && <0.2
@@ -37,7 +37,7 @@ library
     build-depends:
         postgresql-binary >=0.12 && <0.13
       , postgresql-libpq  >=0.9  && <0.10
-      , time              >=1.5  && <1.11
+      , time              >=1.5  && <1.12
       , uuid-types        >=1.0  && <1.1
   hs-source-dirs:
     src

--- a/selda-sqlite/selda-sqlite.cabal
+++ b/selda-sqlite/selda-sqlite.cabal
@@ -29,11 +29,11 @@ library
     , text          >=1.0 && <1.3
   if !flag(haste)
     build-depends:
-        bytestring    >=0.10  && <0.11
+        bytestring    >=0.10  && <0.12
       , direct-sqlite >=2.2   && <2.4
       , directory     >=1.2.2 && <1.4
       , exceptions    >=0.8 && <0.11
-      , time          >=1.5   && <1.11
+      , time          >=1.5   && <1.12
       , uuid-types    >=1.0   && <1.1
   hs-source-dirs:
     src

--- a/selda-tests/selda-tests.cabal
+++ b/selda-tests/selda-tests.cabal
@@ -34,15 +34,15 @@ test-suite selda-testsuite
   build-depends:
       aeson
     , base       >=4.8  && <5
-    , bytestring >=0.10 && <0.11
+    , bytestring >=0.10 && <0.12
     , directory  >=1.2  && <1.4
     , exceptions >=0.8  && <0.11
     , HUnit      >=1.4  && <1.7
     , selda
     , selda-json
     , text       >=1.1  && <1.3
-    , time       >=1.4  && <1.10
-    , random     >=1.1  && <1.2
+    , time       >=1.4  && <1.12
+    , random     >=1.1  && <1.3
     , uuid-types >=1.0  && <1.1
   if flag(postgres)
     other-modules: PGConnectInfo, Tests.PGConnectionString

--- a/selda-tests/test/Tests/Mutable.hs
+++ b/selda-tests/test/Tests/Mutable.hs
@@ -119,7 +119,7 @@ updateUpdates = do
     , (def, Nothing, "more anonymous spam")
     , (def, Nothing, "even more spam")
     ]
-  rows <- update comments (isNull . (!cName))
+  rows <- update comments (isNull . (! cName))
                           (`with` [cName := just "anon"])
   [upd] <- query $ aggregate $ do
     t <- select comments
@@ -327,7 +327,7 @@ nulQueries = do
     , (def, Nothing         , "more \0 spam")
     , (def, Nothing         , "even more spam")
     ]
-  rows <- update comments (isNull . (!cName))
+  rows <- update comments (isNull . (! cName))
                           (`with` [cName := just "\0"])
   [upd] <- query $ aggregate $ do
     t <- select comments

--- a/selda/selda.cabal
+++ b/selda/selda.cabal
@@ -7,7 +7,7 @@ description:         This package provides an EDSL for writing portable, type-sa
                      support.
 
                      See the project website for a comprehensive tutorial.
-                     
+
                      To use this package you need at least one backend package, in addition to
                      this package. There are currently two different backend packages:
                      selda-sqlite and selda-postgresql.
@@ -72,11 +72,11 @@ library
     FlexibleContexts
   build-depends:
       base       >=4.9  && <5
-    , bytestring >=0.10 && <0.11
+    , bytestring >=0.10 && <0.12
     , exceptions >=0.8  && <0.11
     , mtl        >=2.0  && <2.3
     , text       >=1.0  && <1.3
-    , time       >=1.5  && <1.11
+    , time       >=1.5  && <1.12
     , containers >=0.4  && <0.7
     , random     >=1.1  && <1.3
     , uuid-types >=1.0  && <1.1

--- a/stack-ghc-9.0.yaml
+++ b/stack-ghc-9.0.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.28
+resolver: lts-19.9
 
 packages:
 - selda

--- a/stack-ghc-9.2.yaml
+++ b/stack-ghc-9.2.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.28
+resolver: nightly-2022-06-04
 
 packages:
 - selda


### PR DESCRIPTION
The first 2 commits will allow selda packages to be used together with GHC 9.0, GHC 9.2 and newer versions of aeson, bytestring, random & time. The second 2 commits are for development ergonomics.