### PR TITLE
fix: build with mtl 2.3 and ghc 9.6

### DIFF
--- a/selda/src/Database/Selda/Backend/Internal.hs
+++ b/selda/src/Database/Selda/Backend/Internal.hs
@@ -44,7 +44,8 @@ import Control.Monad.Catch
     ( Exception, bracket, MonadCatch, MonadMask, MonadThrow(..) )
 import Control.Monad.IO.Class ( MonadIO(..) )
 import Control.Monad.Reader
-    ( MonadTrans(..), when, ReaderT(..), MonadReader(ask) )
+    ( MonadTrans(..), ReaderT(..), MonadReader(ask) )
+import Control.Monad (when)
 import Data.Dynamic ( Typeable, Dynamic )
 import qualified Data.IntMap as M
 import Data.IORef

--- a/selda/src/Database/Selda/Generic.hs
+++ b/selda/src/Database/Selda/Generic.hs
@@ -9,7 +9,8 @@ module Database.Selda.Generic
   , tblCols, params, def, gNew, gRow
   ) where
 import Control.Monad.State
-    ( liftM2, MonadState(put, get), evalState, State )
+    ( MonadState(put, get), evalState, State )
+import Control.Monad (liftM2)
 import Data.Dynamic ( Typeable )
 import Data.Text as Text (Text, pack)
 

--- a/selda/src/Database/Selda/SQL/Print.hs
+++ b/selda/src/Database/Selda/SQL/Print.hs
@@ -17,7 +17,8 @@ import Database.Selda.SqlType ( Lit(LJust, LNull), SqlTypeRep )
 import Database.Selda.Types
     ( TableName, ColName, fromColName, fromTableName )
 import Control.Monad.State
-    ( liftM2, MonadState(get, put), runState, State )
+    ( MonadState(get, put), runState, State )
+import Control.Monad (liftM2)
 import Data.List ( group, sort )
 import Data.Text (Text)
 import qualified Data.Text as Text

--- a/selda/src/Database/Selda/SqlRow.hs
+++ b/selda/src/Database/Selda/SqlRow.hs
@@ -8,11 +8,11 @@ module Database.Selda.SqlRow
   , runResultReader, next
   ) where
 import Control.Monad.State.Strict
-    ( liftM2,
-      StateT(StateT),
+    ( StateT(StateT),
       MonadState(state, get),
       State,
       evalState )
+import Control.Monad (liftM2)
 import Database.Selda.SqlType
     ( SqlValue(SqlNull), SqlType(fromSql) )
 import Data.Typeable ( Typeable, Proxy(..) )

--- a/selda/src/Database/Selda/Unsafe.hs
+++ b/selda/src/Database/Selda/Unsafe.hs
@@ -10,7 +10,8 @@ module Database.Selda.Unsafe
   ) where
 import Control.Exception (throw)
 import Control.Monad.State.Strict
-    ( MonadIO(liftIO), void, MonadState(put, get) )
+    ( MonadIO(liftIO), MonadState(put, get) )
+import Control.Monad (void)
 import Database.Selda.Backend.Internal
     ( SqlType(mkLit, sqlType),
       MonadSelda,


### PR DESCRIPTION
That's only import fixs, some symbol from `base` are not reexported by `mtl` anymore. This commit uses the version from `base` instead.