### PR TITLE
Cascade

### DIFF
--- a/selda-postgresql/src/Database/Selda/PostgreSQL.hs
+++ b/selda-postgresql/src/Database/Selda/PostgreSQL.hs
@@ -274,13 +274,12 @@ pgGetTableInfo c tbl = do
         Right (_, fks) <- pgQueryRunner c False fkquery []
         Right (_, ixs) <- pgQueryRunner c False ixquery []
         colInfos <- mapM (describe fks (map toText ixs)) vals
-        x <- pure $ TableInfo
+        pure $ TableInfo
           { tableInfoName = mkTableName tbl
           , tableColumnInfos = colInfos
           , tableUniqueGroups = map (map mkColName) uniques
           , tablePrimaryKey = [mkColName pk | [SqlString pk] <- pkInfo]
           }
-        pure x
   where
     splitNames = breakNames . toText
     -- TODO: this is super ugly; should really be fixed

--- a/selda/src/Database/Selda/Backend/Internal.hs
+++ b/selda/src/Database/Selda/Backend/Internal.hs
@@ -182,7 +182,7 @@ fromColInfo ci = ColumnInfo
     , colFKs = map fk (Table.colFKs ci)
     }
   where
-    fk (Table tbl _ _ _, col) = (tbl, col)
+    fk (Table tbl _ _ _, col, _) = (tbl, col)
 
 -- | Get the column information for each column in the given table.
 tableInfo :: Table a -> TableInfo

--- a/selda/src/Database/Selda/Table.hs
+++ b/selda/src/Database/Selda/Table.hs
@@ -210,7 +210,7 @@ unique = Attribute [Unique]
 
 mkFK :: Table t -> Selector a b -> Attribute Selector c d
 mkFK (Table tn tcs tapk tas) sel =
-  ForeignKey (Table tn tcs tapk tas, colName (tcs !! selectorIndex sel))
+  ForeignKey (Table tn tcs tapk tas, colName (tcs !! selectorIndex sel), False)
 
 class ForeignKey a b where
   -- | A foreign key constraint referencing the given table and column.

--- a/selda/src/Database/Selda/Table.hs
+++ b/selda/src/Database/Selda/Table.hs
@@ -1,6 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE TypeFamilies, TypeOperators, FlexibleInstances #-}
-{-# LANGUAGE UndecidableInstances, MultiParamTypeClasses, OverloadedStrings #-}
+{-# LANGUAGE UndecidableInstances, MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleContexts, ScopedTypeVariables, ConstraintKinds #-}
 {-# LANGUAGE GADTs, CPP, DataKinds #-}
 {-# LANGUAGE TypeApplications #-}
@@ -16,9 +16,10 @@ module Database.Selda.Table
   , tableExpr
   , isAutoPrimary, isPrimary, isUnique
   ) where
+import Data.Kind (Type)
 import Data.Text (Text)
 import Data.Typeable ( Proxy(..) )
-import Database.Selda.Types ( type (:*:), TableName, ColName )
+import Database.Selda.Types ( type (:*:), TableName )
 import Database.Selda.Selectors ( Selector(..) )
 import Database.Selda.SqlType ( ID, RowID )
 import Database.Selda.Column (Row (..))
@@ -27,6 +28,7 @@ import Database.Selda.Table.Type
     ( IndexMethod(..),
       ColAttr(..),
       AutoIncType(..),
+      ColForeignKey,
       ColInfo(..),
       Table(..),
       isAutoPrimary,
@@ -163,9 +165,9 @@ tidy ci = ci {colAttrs = snub $ colAttrs ci}
 
 -- | Some attribute that may be set on a column of type @c@, in a table of
 --   type @t@.
-data Attribute (g :: * -> * -> *) t c
+data Attribute (g :: Type -> Type -> Type) t c
   = Attribute [ColAttr]
-  | ForeignKey (Table (), ColName)
+  | ForeignKey ColForeignKey
 
 -- | A primary key which does not auto-increment.
 primary :: Attribute Group t a

--- a/selda/src/Database/Selda/Table.hs
+++ b/selda/src/Database/Selda/Table.hs
@@ -208,20 +208,31 @@ weakUntypedAutoPrimary = Attribute [AutoPrimary Weak, Required]
 unique :: Attribute Group t a
 unique = Attribute [Unique]
 
-mkFK :: Table t -> Selector a b -> Attribute Selector c d
-mkFK (Table tn tcs tapk tas) sel =
-  ForeignKey (Table tn tcs tapk tas, colName (tcs !! selectorIndex sel), False)
+mkFK :: Bool -> Table t -> Selector a b -> Attribute Selector c d
+mkFK isCascading (Table tn tcs tapk tas) sel =
+  ForeignKey (Table tn tcs tapk tas, colName (tcs !! selectorIndex sel), isCascading)
 
 class ForeignKey a b where
   -- | A foreign key constraint referencing the given table and column.
   foreignKey :: Table t -> Selector t a -> Attribute Selector self b
 
 instance ForeignKey a a where
-  foreignKey = mkFK
+  foreignKey = mkFK False
 instance ForeignKey (Maybe a) a where
-  foreignKey = mkFK
+  foreignKey = mkFK False
 instance ForeignKey a (Maybe a) where
-  foreignKey = mkFK
+  foreignKey = mkFK False
+
+class ForeignKeyCascading a b where
+  -- | A foreign key constraint with referential integrity referencing the given table and column.
+  foreignKeyCascading :: Table t -> Selector t a -> Attribute Selector self b
+
+instance ForeignKeyCascading a a where
+  foreignKeyCascading = mkFK True
+instance ForeignKeyCascading (Maybe a) a where
+  foreignKeyCascading = mkFK True
+instance ForeignKeyCascading a (Maybe a) where
+  foreignKeyCascading = mkFK True
 
 -- | An expression representing the given table.
 tableExpr :: Table a -> Row s a

--- a/selda/src/Database/Selda/Table/Compile.hs
+++ b/selda/src/Database/Selda/Table/Compile.hs
@@ -112,12 +112,14 @@ compileCreateIndex cfg ifex tbl cols mmethod = mconcat
 
 -- | Compile a foreign key constraint.
 compileFK :: ColName -> ColForeignKey -> Int -> Text
-compileFK col (Table ftbl _ _ _, fcol) n = mconcat
+compileFK col (Table ftbl _ _ _, fcol, isCascading) n = mconcat
   [ "CONSTRAINT ", fkName, " FOREIGN KEY (", fromColName col, ") "
   , "REFERENCES ", fromTableName ftbl, "(", fromColName fcol, ")"
+  , onDeleteCascade
   ]
   where
     fkName = fromColName $ addColPrefix col ("fk" <> pack (show n) <> "_")
+    onDeleteCascade = if isCascading then " ON DELETE CASCADE" else ""
 
 -- | Compile a table column.
 compileTableCol :: PPConfig -> ColInfo -> Text

--- a/selda/src/Database/Selda/Table/Compile.hs
+++ b/selda/src/Database/Selda/Table/Compile.hs
@@ -4,6 +4,7 @@ module Database.Selda.Table.Compile where
 import Database.Selda.Table.Type
     ( IndexMethod,
       ColAttr(Indexed, Primary, Unique),
+      ColForeignKey,
       ColInfo(colFKs, colType, colName, colAttrs),
       Table(Table, tableAttrs, tableName, tableCols),
       isAutoPrimary )
@@ -110,7 +111,7 @@ compileCreateIndex cfg ifex tbl cols mmethod = mconcat
   ]
 
 -- | Compile a foreign key constraint.
-compileFK :: ColName -> (Table (), ColName) -> Int -> Text
+compileFK :: ColName -> ColForeignKey -> Int -> Text
 compileFK col (Table ftbl _ _ _, fcol) n = mconcat
   [ "CONSTRAINT ", fkName, " FOREIGN KEY (", fromColName col, ") "
   , "REFERENCES ", fromTableName ftbl, "(", fromColName fcol, ")"

--- a/selda/src/Database/Selda/Table/Type.hs
+++ b/selda/src/Database/Selda/Table/Type.hs
@@ -23,12 +23,14 @@ data Table a = Table
   , tableAttrs :: [([Int], ColAttr)]
   }
 
+type ColForeignKey = (Table (), ColName)
+
 -- | A complete description of a database column.
 data ColInfo = ColInfo
   { colName  :: ColName
   , colType  :: SqlTypeRep
   , colAttrs :: [ColAttr]
-  , colFKs   :: [(Table (), ColName)]
+  , colFKs   :: [ColForeignKey]
   , colExpr  :: UntypedCol SQL
   }
 

--- a/selda/src/Database/Selda/Table/Type.hs
+++ b/selda/src/Database/Selda/Table/Type.hs
@@ -23,7 +23,7 @@ data Table a = Table
   , tableAttrs :: [([Int], ColAttr)]
   }
 
-type ColForeignKey = (Table (), ColName)
+type ColForeignKey = (Table (), ColName, Bool)
 
 -- | A complete description of a database column.
 data ColInfo = ColInfo

--- a/selda/src/Database/Selda/Table/Validation.hs
+++ b/selda/src/Database/Selda/Table/Validation.hs
@@ -21,7 +21,7 @@ import Database.Selda.Types
 --
 --   Therefore, it is not meaningful to handle this exception in any way,
 --   just fix your bug instead.
-data ValidationError = ValidationError String
+newtype ValidationError = ValidationError String
   deriving (Show, Eq, Typeable)
 instance Exception ValidationError
 

--- a/selda/src/Database/Selda/Table/Validation.hs
+++ b/selda/src/Database/Selda/Table/Validation.hs
@@ -62,7 +62,7 @@ validate name cis = errs
       [ "column is used as a foreign key, but is not primary or unique: "
           <> fromTableName ftn <> "." <> fromColName fcn
       | ci <- cis
-      , (Table ftn fcs _ _, fcn) <- colFKs ci
+      , (Table ftn fcs _ _, fcn, _) <- colFKs ci
       , fc <- fcs
       , colName fc == fcn
       , not $ Prelude.any isUnique (colAttrs fc)


### PR DESCRIPTION
Using `foreignKeyCascading` instead of `foreignKey`, `ON DELETE CASCADE` should be added to the foreign key constraint when a table is created.