### PR TITLE
Improve monad transformers support

### DIFF
--- a/selda-tests/selda-tests.cabal
+++ b/selda-tests/selda-tests.cabal
@@ -38,6 +38,7 @@ test-suite selda-testsuite
     , directory  >=1.2  && <1.4
     , exceptions >=0.8  && <0.11
     , HUnit      >=1.4  && <1.7
+    , mtl        >=2.0  && <2.4
     , selda
     , selda-json
     , text       >=1.1  && <2.1

--- a/selda/selda.cabal
+++ b/selda/selda.cabal
@@ -73,7 +73,7 @@ library
   build-depends:
       base       >=4.10 && <5
     , bytestring >=0.10 && <0.12
-    , exceptions >=0.8  && <0.11
+    , exceptions >=0.9  && <0.11
     , mtl        >=2.0  && <2.4
     , text       >=1.0  && <2.1
     , time       >=1.5  && <1.13


### PR DESCRIPTION
This PR fixes the following limitations:

 - Some class instances from the base monad could not pass through `SeldaT`, ie. `SeldaT b (StateT s IO)` did not have a ` MonadState s` instance,
 - `SeldaT` could only be used as outermost element in the transformer stack, ie. `StateT s (SeldaT b IO)` did not have a `MonadSelda` instance,
 - The use of `onException` made it unsafe to use a base monad that uses any form of short-circuiting that is not an exception, ie. ExceptT.

Fixing that last point requires using `generalBracket` introduced in `exceptions-0.9`, so I had to bump the dependency requirement. I am not sure how this impacts the range of GHC versions that can be supported.

Supporting `ExceptT`/`MonadError` is rather important for applications based on servant.