### PR TITLE
Implementing streaming support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ghc: ['8.8.2', '8.10.1', '9.2.5', '9.4.4']
+        ghc: ['8.8.2', '8.10.1', '9.2.5', '9.4.4', '9.12.2']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If you want to contribute code, please consult the following checklist before
 sending a pull request:
 
 * Does the code build with a recent version of GHC?
-* Do all the tests pass?
+* Do all the tests pass? Run `make test` in the root of the repo.
 * Have you added any tests covering your code?
 
 If you want to contribute code but don't really know where to begin,

--- a/selda-build-tools.cabal
+++ b/selda-build-tools.cabal
@@ -11,6 +11,6 @@ executable selda-changelog
   build-depends:
     base     >=4.8 && <5,
     time     >=1.5 && <1.15,
-    filepath >=1.4 && <1.5,
+    filepath >=1.4 && <1.6,
     process  >=1.5 && <1.7
   default-language: Haskell2010

--- a/selda-build-tools.cabal
+++ b/selda-build-tools.cabal
@@ -10,7 +10,7 @@ executable selda-changelog
   main-is: ChangeLog.hs
   build-depends:
     base     >=4.8 && <5,
-    time     >=1.5 && <1.10,
+    time     >=1.5 && <1.15,
     filepath >=1.4 && <1.5,
     process  >=1.5 && <1.7
   default-language: Haskell2010

--- a/selda-json/selda-json.cabal
+++ b/selda-json/selda-json.cabal
@@ -19,7 +19,7 @@ library
   build-depends:
       aeson      >=1.0  && <2.2
     , base       >=4.9  && <5
-    , bytestring >=0.10 && <0.12
+    , bytestring >=0.10 && <0.13
     , selda      >=0.4  && <0.6
     , text       >=1.0  && <2.1
   hs-source-dirs:      src

--- a/selda-json/selda-json.cabal
+++ b/selda-json/selda-json.cabal
@@ -17,10 +17,10 @@ library
   exposed-modules:
     Database.Selda.JSON
   build-depends:
-      aeson      >=1.0  && <2.2
+      aeson      >=1.0  && <2.3
     , base       >=4.9  && <5
     , bytestring >=0.10 && <0.13
     , selda      >=0.4  && <0.6
-    , text       >=1.0  && <2.1
+    , text       >=1.0  && <2.2
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/selda-postgresql/selda-postgresql.cabal
+++ b/selda-postgresql/selda-postgresql.cabal
@@ -28,7 +28,7 @@ library
     CPP
   build-depends:
       base       >=4.9 && <5
-    , bytestring >=0.9 && <0.12
+    , bytestring >=0.9 && <0.13
     , exceptions >=0.8 && <0.11
     , selda      >=0.5 && <0.6
     , selda-json >=0.1 && <0.2

--- a/selda-postgresql/selda-postgresql.cabal
+++ b/selda-postgresql/selda-postgresql.cabal
@@ -32,7 +32,7 @@ library
     , exceptions >=0.8 && <0.11
     , selda      >=0.5 && <0.6
     , selda-json >=0.1 && <0.2
-    , text       >=1.0 && <2.1
+    , text       >=1.0 && <2.2
   if !flag(haste)
     build-depends:
         postgresql-binary >=0.12 && <0.13

--- a/selda-postgresql/selda-postgresql.cabal
+++ b/selda-postgresql/selda-postgresql.cabal
@@ -37,7 +37,7 @@ library
     build-depends:
         postgresql-binary >=0.12 && <0.13
       , postgresql-libpq  >=0.9  && <0.10
-      , time              >=1.5  && <1.13
+      , time              >=1.5  && <1.15
       , uuid-types        >=1.0  && <1.1
   hs-source-dirs:
     src

--- a/selda-postgresql/src/Database/Selda/PostgreSQL.hs
+++ b/selda-postgresql/src/Database/Selda/PostgreSQL.hs
@@ -201,7 +201,7 @@ pgBackend :: Connection   -- ^ PostgreSQL connection object.
           -> SeldaBackend PG
 pgBackend c = SeldaBackend
   { runStmt          = \q ps -> right <$> pgQueryRunner c False q ps
-  , runStmtStreaming = undefined
+  , runStmtStreaming = \f q ps -> undefined
   , runStmtWithPK    = \q ps -> left <$> pgQueryRunner c True q ps
   , prepareStmt      = pgPrepare c
   , runPrepared      = pgRun c

--- a/selda-postgresql/src/Database/Selda/PostgreSQL.hs
+++ b/selda-postgresql/src/Database/Selda/PostgreSQL.hs
@@ -200,14 +200,15 @@ pgPPConfig = defPPConfig
 pgBackend :: Connection   -- ^ PostgreSQL connection object.
           -> SeldaBackend PG
 pgBackend c = SeldaBackend
-  { runStmt         = \q ps -> right <$> pgQueryRunner c False q ps
-  , runStmtWithPK   = \q ps -> left <$> pgQueryRunner c True q ps
-  , prepareStmt     = pgPrepare c
-  , runPrepared     = pgRun c
-  , getTableInfo    = pgGetTableInfo c . rawTableName
-  , backendId       = PostgreSQL
-  , ppConfig        = pgPPConfig
-  , closeConnection = \_ -> finish c
+  { runStmt          = \q ps -> right <$> pgQueryRunner c False q ps
+  , runStmtStreaming = undefined
+  , runStmtWithPK    = \q ps -> left <$> pgQueryRunner c True q ps
+  , prepareStmt      = pgPrepare c
+  , runPrepared      = pgRun c
+  , getTableInfo     = pgGetTableInfo c . rawTableName
+  , backendId        = PostgreSQL
+  , ppConfig         = pgPPConfig
+  , closeConnection  = \_ -> finish c
   , disableForeignKeys = disableFKs c
   }
   where

--- a/selda-sqlite/selda-sqlite.cabal
+++ b/selda-sqlite/selda-sqlite.cabal
@@ -29,7 +29,7 @@ library
     , text          >=1.0 && <2.1
   if !flag(haste)
     build-depends:
-        bytestring    >=0.10  && <0.12
+        bytestring    >=0.10  && <0.13
       , direct-sqlite >=2.2   && <2.4
       , directory     >=1.2.2 && <1.4
       , exceptions    >=0.8   && <0.11

--- a/selda-sqlite/selda-sqlite.cabal
+++ b/selda-sqlite/selda-sqlite.cabal
@@ -26,7 +26,7 @@ library
   build-depends:
       base          >=4.9 && <5
     , selda         >=0.5 && <0.6
-    , text          >=1.0 && <2.1
+    , text          >=1.0 && <2.2
   if !flag(haste)
     build-depends:
         bytestring    >=0.10  && <0.13

--- a/selda-sqlite/selda-sqlite.cabal
+++ b/selda-sqlite/selda-sqlite.cabal
@@ -33,7 +33,7 @@ library
       , direct-sqlite >=2.2   && <2.4
       , directory     >=1.2.2 && <1.4
       , exceptions    >=0.8   && <0.11
-      , time          >=1.5   && <1.13
+      , time          >=1.5   && <1.15
       , uuid-types    >=1.0   && <1.1
   hs-source-dirs:
     src

--- a/selda-sqlite/src/Database/Selda/SQLite.hs
+++ b/selda-sqlite/src/Database/Selda/SQLite.hs
@@ -67,7 +67,7 @@ withSQLite file m = bracket (sqliteOpen file) seldaClose (runSeldaT m)
 sqliteBackend :: Database -> SeldaBackend SQLite
 sqliteBackend db = SeldaBackend
   { runStmt          = \q ps -> snd <$> sqliteQueryRunner db q ps
-  , runStmtStreaming = \q ps -> snd <$> sqliteQueryRunnerStreaming db q ps
+  , runStmtStreaming = \q ps -> sqliteQueryRunnerStreaming db q ps
   , runStmtWithPK    = \q ps -> fst <$> sqliteQueryRunner db q ps
   , prepareStmt      = \_ _ -> sqlitePrepare db
   , runPrepared      = sqliteRunPrepared db
@@ -199,20 +199,20 @@ sqliteRunStmt db stm params = do
   cs <- changes db
   return (fromIntegral rid, (cs, [map fromSqlData r | r <- rows]))
 
-sqliteQueryRunnerStreaming :: Database -> QueryRunner (Generator st)
-sqliteQueryRunnerStreaming db qry params = do
+sqliteQueryRunnerStreaming :: MonadIO m, Monoid a => (st -> m a) -> Database -> QueryRunner (m [SqlValue])
+sqliteQueryRunnerStreaming f db qry params = do
     eres <- try $ do
       stm <- prepare db qry
-      sqliteRunStmtStreaming db stm params `finally` do
+      sqliteRunStmtStreaming f db stm params `finally` do
         finalize stm
     case eres of
       Left e@(SQLError{}) -> throwM (SqlError (show e))
       Right res           -> return res
 
-sqliteRunStmtStreaming :: Database -> Statement -> [Param] -> IO (Generator st)
-sqliteRunStmtStreaming db stm params = do
+sqliteRunStmtStreaming :: MonadIO m, Monoid a => (st -> m a) -> Database -> Statement -> [Param] -> IO (m [SqlValue])
+sqliteRunStmtStreaming f db stm params = do
   bind stm [toSqlData p | Param p <- params]
-  rows <- streamRows stm []
+  rows <- streamRows f stm []
   _rid <- lastInsertRowId db
   !cs <- changes db
   return rows -- this should be roughly correct
@@ -227,15 +227,16 @@ getRows s acc = do
     _ -> do
       return $ reverse acc
 
-streamRows :: Statement -> [[SQLData]] -> Generator st
-streamRows s acc = \st -> do
+-- TODO: should return `Generator [SqlData]`
+streamRows :: MonadIO m, Monoid a => (st -> m a) -> Statement -> [[SQLData]] -> IO (m [SqlValue])
+streamRows f s acc = do
   res <- step s
   case res of
     Row -> do
-      cs <- columns s
-      yield cs
-    -- _ -> 
-    -- what do we do instead of returning all accumulated values?
+      cs <- columns s -- :: IO [SQLData]
+      streamRows s `mappend` (f $ fromSqlData cs) `mappend` acc
+    Done -> do
+      return $ reverse acc
 
 toSqlData :: Lit a -> SQLData
 toSqlData (LInt32 i)    = SQLInteger $ fromIntegral i

--- a/selda-sqlite/src/Database/Selda/SQLite.hs
+++ b/selda-sqlite/src/Database/Selda/SQLite.hs
@@ -3,6 +3,7 @@
 module Database.Selda.SQLite
   ( SQLite
   , withSQLite
+  , withSQLiteStreaming
   , sqliteOpen, seldaClose
   , sqliteBackend
   ) where
@@ -55,6 +56,11 @@ sqliteBackend :: a -> SeldaBackend
 sqliteBackend _ = error "sqliteBackend called in JS context"
 #else
 withSQLite file m = bracket (sqliteOpen file) seldaClose (runSeldaT m)
+
+--withSQLiteStreaming ::
+withSQLiteStreaming :: (MonadMask m, MonadIO m, Monoid (m b)) => FilePath -> SeldaT SQLite m b -> m b
+withSQLiteStreaming file m = bracket (sqliteOpen file) seldaClose (runSeldaT m)
+-- S.yield :: Monad m => a -> S.Stream (S.Of a) m ()
 
 -- | Create a Selda backend using an already open database handle.
 --   This is useful for situations where you want to use some SQLite-specific

--- a/selda-sqlite/src/Database/Selda/SQLite.hs
+++ b/selda-sqlite/src/Database/Selda/SQLite.hs
@@ -57,10 +57,9 @@ sqliteBackend _ = error "sqliteBackend called in JS context"
 #else
 withSQLite file m = bracket (sqliteOpen file) seldaClose (runSeldaT m)
 
---withSQLiteStreaming ::
-withSQLiteStreaming :: (MonadMask m, MonadIO m, Monoid (m b)) => FilePath -> SeldaT SQLite m b -> m b
-withSQLiteStreaming file m = bracket (sqliteOpen file) seldaClose (runSeldaT m)
 -- S.yield :: Monad m => a -> S.Stream (S.Of a) m ()
+withSQLiteStreaming :: (MonadMask m, MonadIO m, Monad m, Monoid (m b)) => FilePath -> SeldaT SQLite m b -> m b
+withSQLiteStreaming file m = bracket (sqliteOpen file) seldaClose (runSeldaT m)
 
 -- | Create a Selda backend using an already open database handle.
 --   This is useful for situations where you want to use some SQLite-specific

--- a/selda-tests/selda-tests.cabal
+++ b/selda-tests/selda-tests.cabal
@@ -34,7 +34,7 @@ test-suite selda-testsuite
   build-depends:
       aeson
     , base       >=4.8  && <5
-    , bytestring >=0.10 && <0.12
+    , bytestring >=0.10 && <0.13
     , directory  >=1.2  && <1.4
     , exceptions >=0.8  && <0.11
     , HUnit      >=1.4  && <1.7

--- a/selda-tests/selda-tests.cabal
+++ b/selda-tests/selda-tests.cabal
@@ -33,15 +33,15 @@ test-suite selda-testsuite
     Tests.Validation
   build-depends:
       aeson
-    , base       >=4.8  && <5
+    , base       >=4.10  && <5
     , bytestring >=0.10 && <0.13
     , directory  >=1.2  && <1.4
     , exceptions >=0.8  && <0.11
     , HUnit      >=1.4  && <1.7
     , selda
     , selda-json
-    , text       >=1.1  && <2.1
-    , time       >=1.4  && <1.13
+    , text       >=1.1  && <2.2
+    , time       >=1.4  && <1.15
     , random     >=1.1  && <1.3
     , uuid-types >=1.0  && <1.1
   if flag(postgres)

--- a/selda-tests/test/Tests/Query.hs
+++ b/selda-tests/test/Tests/Query.hs
@@ -67,6 +67,7 @@ queryTests run = test
   , "nonNull" ~: run nonNullYieldsEmptyResult
   , "rawQuery1" ~: run rawQuery1Works
   , "rawQuery" ~: run rawQueryWorks
+  , "rawQueryStreaming" ~: run rawQueryStreamingWorks
   , "union" ~: run unionWorks
   , "union discards dupes" ~: run unionDiscardsDupes
   , "union works for whole rows" ~: run unionWorksForWholeRows
@@ -617,6 +618,13 @@ rawQueryWorks = do
     p <- rawQuery ["name", "age", "pet", "cash"]
                   ("SELECT * FROM people WHERE name = " <> injLit ("Link"::Text))
     return p
+  let correct = [p | p <- peopleItems, name p == "Link"]
+  assEq "wrong name list returned" correct ppl
+
+rawQueryStreamingWorks = do
+  let q = rawQuery ["name", "age", "pet", "cash"]
+                  ("SELECT * FROM people WHERE name = " <> injLit ("Link"::Text))
+  ppl <- forQuery q $ pure . (:[])
   let correct = [p | p <- peopleItems, name p == "Link"]
   assEq "wrong name list returned" correct ppl
 

--- a/selda/selda.cabal
+++ b/selda/selda.cabal
@@ -75,7 +75,7 @@ library
     , bytestring >=0.10 && <0.13
     , exceptions >=0.8  && <0.11
     , mtl        >=2.0  && <2.4
-    , text       >=1.0  && <2.1
+    , text       >=1.0  && <2.2
     , time       >=1.5  && <1.15
     , containers >=0.4  && <0.7
     , random     >=1.1  && <1.3

--- a/selda/selda.cabal
+++ b/selda/selda.cabal
@@ -72,7 +72,7 @@ library
     FlexibleContexts
   build-depends:
       base       >=4.10 && <5
-    , bytestring >=0.10 && <0.12
+    , bytestring >=0.10 && <0.13
     , exceptions >=0.8  && <0.11
     , mtl        >=2.0  && <2.4
     , text       >=1.0  && <2.1

--- a/selda/selda.cabal
+++ b/selda/selda.cabal
@@ -18,7 +18,7 @@ maintainer:          anton@ekblad.cc
 category:            Database
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC == 8.8.2, GHC == 8.10.1, GHC == 9.2.5, GHC == 9.4.4
+tested-with:         GHC == 8.8.2, GHC == 8.10.1, GHC == 9.2.5, GHC == 9.4.4, GHC == 9.12.2
 
 source-repository head
   type:     git

--- a/selda/selda.cabal
+++ b/selda/selda.cabal
@@ -77,7 +77,7 @@ library
     , mtl        >=2.0  && <2.4
     , text       >=1.0  && <2.2
     , time       >=1.5  && <1.15
-    , containers >=0.4  && <0.7
+    , containers >=0.4  && <0.8
     , random     >=1.1  && <1.3
     , uuid-types >=1.0  && <1.1
   hs-source-dirs:

--- a/selda/selda.cabal
+++ b/selda/selda.cabal
@@ -76,7 +76,7 @@ library
     , exceptions >=0.8  && <0.11
     , mtl        >=2.0  && <2.4
     , text       >=1.0  && <2.1
-    , time       >=1.5  && <1.13
+    , time       >=1.5  && <1.15
     , containers >=0.4  && <0.7
     , random     >=1.1  && <1.3
     , uuid-types >=1.0  && <1.1

--- a/selda/src/Database/Selda.hs
+++ b/selda/src/Database/Selda.hs
@@ -27,7 +27,7 @@ module Database.Selda
   , SeldaT, SeldaM
   , Relational, Only (..), The (..)
   , Table (tableName), Query, Row, Col, Res, Result
-  , query, queryInto
+  , query, queryStream, queryInto
   , transaction, withoutForeignKeyEnforcement
   , newUuid
 
@@ -156,6 +156,7 @@ import Database.Selda.FieldSelectors
 import Database.Selda.Frontend
     ( MonadIO(..),
       query,
+      queryStream,
       queryInto,
       insert,
       tryInsert,

--- a/selda/src/Database/Selda/Backend.hs
+++ b/selda/src/Database/Selda/Backend.hs
@@ -3,6 +3,7 @@
 module Database.Selda.Backend
   ( MonadSelda (..), SeldaT, SeldaM, SeldaError (..)
   , StmtID, BackendID (..), QueryRunner, SeldaBackend (..), SeldaConnection
+  , Generator
   , SqlValue (..)
   , IndexMethod (..)
   , Param (..), ColAttr (..), AutoIncType (..)
@@ -32,6 +33,7 @@ import Database.Selda.Backend.Internal
       SeldaT,
       MonadSelda(..),
       SeldaBackend(..),
+      Generator,
       ColumnInfo(..),
       TableInfo(..),
       SeldaConnection(connClosed, connBackend),

--- a/selda/src/Database/Selda/Backend.hs
+++ b/selda/src/Database/Selda/Backend.hs
@@ -3,7 +3,6 @@
 module Database.Selda.Backend
   ( MonadSelda (..), SeldaT, SeldaM, SeldaError (..)
   , StmtID, BackendID (..), QueryRunner, SeldaBackend (..), SeldaConnection
-  , Generator
   , SqlValue (..)
   , IndexMethod (..)
   , Param (..), ColAttr (..), AutoIncType (..)
@@ -33,7 +32,6 @@ import Database.Selda.Backend.Internal
       SeldaT,
       MonadSelda(..),
       SeldaBackend(..),
-      Generator,
       ColumnInfo(..),
       TableInfo(..),
       SeldaConnection(connClosed, connBackend),

--- a/selda/src/Database/Selda/Backend/Internal.hs
+++ b/selda/src/Database/Selda/Backend/Internal.hs
@@ -217,7 +217,7 @@ data SeldaBackend b st = SeldaBackend
     runStmt :: Text -> [Param] -> IO (Int, [[SqlValue]])
 
     -- | Stream the result.
-  , runStmtStreaming :: MonadIO m => Text -> [Param] -> IO (m [SqlValue])
+  , runStmtStreaming :: MonadIO m => (SqlValue -> m a) -> Text -> [Param] -> IO (m [SqlValue])
 
     -- | Execute an SQL statement and return the last inserted primary key,
     --   where the primary key is auto-incrementing.

--- a/selda/src/Database/Selda/Backend/Internal.hs
+++ b/selda/src/Database/Selda/Backend/Internal.hs
@@ -211,15 +211,13 @@ tableInfo t = TableInfo
         ]
       ]
 
-type Generator st = IO (st -> Maybe (st, [SqlValue]))
-
 -- | A collection of functions making up a Selda backend.
 data SeldaBackend b st = SeldaBackend
   { -- | Execute an SQL statement.
     runStmt :: Text -> [Param] -> IO (Int, [[SqlValue]])
 
     -- | Stream the result.
-  , runStmtStreaming :: Text -> [Param] -> Generator st
+  , runStmtStreaming :: MonadIO m => Text -> [Param] -> IO (m [SqlValue])
 
     -- | Execute an SQL statement and return the last inserted primary key,
     --   where the primary key is auto-incrementing.

--- a/selda/src/Database/Selda/Backend/Internal.hs
+++ b/selda/src/Database/Selda/Backend/Internal.hs
@@ -211,10 +211,15 @@ tableInfo t = TableInfo
         ]
       ]
 
+type Generator st = IO (st -> Maybe (st, [SqlValue]))
+
 -- | A collection of functions making up a Selda backend.
-data SeldaBackend b = SeldaBackend
+data SeldaBackend b st = SeldaBackend
   { -- | Execute an SQL statement.
     runStmt :: Text -> [Param] -> IO (Int, [[SqlValue]])
+
+    -- | Stream the result.
+  , runStmtStreaming :: Text -> [Param] -> Generator st
 
     -- | Execute an SQL statement and return the last inserted primary key,
     --   where the primary key is auto-incrementing.

--- a/selda/src/Database/Selda/Backend/Internal.hs
+++ b/selda/src/Database/Selda/Backend/Internal.hs
@@ -40,11 +40,12 @@ import Database.Selda.SQL.Print.Config
 import Database.Selda.Types (TableName, ColName)
 import Data.Int (Int64)
 import Control.Concurrent ( newMVar, putMVar, takeMVar, MVar )
+import Control.Monad (when)
 import Control.Monad.Catch
     ( Exception, bracket, MonadCatch, MonadMask, MonadThrow(..) )
 import Control.Monad.IO.Class ( MonadIO(..) )
 import Control.Monad.Reader
-    ( MonadTrans(..), when, ReaderT(..), MonadReader(ask) )
+    ( MonadTrans(..), ReaderT(..), MonadReader(ask) )
 import Data.Dynamic ( Typeable, Dynamic )
 import qualified Data.IntMap as M
 import Data.IORef

--- a/selda/src/Database/Selda/Frontend.hs
+++ b/selda/src/Database/Selda/Frontend.hs
@@ -15,7 +15,7 @@ import Database.Selda.Backend.Internal
       Param,
       SeldaT,
       MonadSelda(..),
-      SeldaBackend(runStmtWithPK, disableForeignKeys, ppConfig, runStmt),
+      SeldaBackend(runStmtWithPK, disableForeignKeys, ppConfig, runStmt, runStmtStreaming),
       QueryRunner,
       SeldaError(SqlError),
       withBackend )
@@ -57,6 +57,10 @@ import Control.Monad.IO.Class ( MonadIO(..) )
 --   such as 'withSQLite' from the SQLite backend.
 query :: (MonadSelda m, Result a) => Query (Backend m) a -> m [Res a]
 query q = withBackend (flip queryWith q . runStmt)
+
+-- | Run a query within a Selda monad like `query` and stream the results.
+queryStreaming :: (MonadSelda m, Result a) => Query (Backend m) a -> m (Generator st)
+queryStreaming withBackend (flip _ q . runStmtStreaming) -- TODO: roll own queryWith to use here
 
 -- | Perform the given query, and insert the result into the given table.
 --   Returns the number of inserted rows.

--- a/selda/src/Database/Selda/Generic.hs
+++ b/selda/src/Database/Selda/Generic.hs
@@ -8,8 +8,9 @@ module Database.Selda.Generic
   ( Relational, Generic
   , tblCols, params, def, gNew, gRow
   ) where
+import Control.Monad (liftM2)
 import Control.Monad.State
-    ( liftM2, MonadState(put, get), evalState, State )
+    ( MonadState(put, get), evalState, State )
 import Data.Dynamic ( Typeable )
 import Data.Text as Text (Text, pack)
 

--- a/selda/src/Database/Selda/SQL/Print.hs
+++ b/selda/src/Database/Selda/SQL/Print.hs
@@ -16,8 +16,9 @@ import qualified Database.Selda.SQL.Print.Config as Cfg
 import Database.Selda.SqlType ( Lit(LJust, LNull), SqlTypeRep )
 import Database.Selda.Types
     ( TableName, ColName, fromColName, fromTableName )
+import Control.Monad (liftM2)
 import Control.Monad.State
-    ( liftM2, MonadState(get, put), runState, State )
+    ( MonadState(get, put), runState, State )
 import Data.List ( group, sort )
 import Data.Text (Text)
 import qualified Data.Text as Text

--- a/selda/src/Database/Selda/SqlRow.hs
+++ b/selda/src/Database/Selda/SqlRow.hs
@@ -7,9 +7,9 @@ module Database.Selda.SqlRow
   , GSqlRow
   , runResultReader, next
   ) where
+import Control.Monad (liftM2)
 import Control.Monad.State.Strict
-    ( liftM2,
-      StateT(StateT),
+    ( StateT(StateT),
       MonadState(state, get),
       State,
       evalState )

--- a/selda/src/Database/Selda/Unsafe.hs
+++ b/selda/src/Database/Selda/Unsafe.hs
@@ -9,8 +9,9 @@ module Database.Selda.Unsafe
   , QueryFragment, inj, injLit, rawName, rawExp, rawStm, rawQuery, rawQuery1
   ) where
 import Control.Exception (throw)
+import Control.Monad (void)
 import Control.Monad.State.Strict
-    ( MonadIO(liftIO), void, MonadState(put, get) )
+    ( MonadIO(liftIO), MonadState(put, get) )
 import Database.Selda.Backend.Internal
     ( SqlType(mkLit, sqlType),
       MonadSelda,


### PR DESCRIPTION
Provided package `streaming` is installed, the utility is demonstrated as follows:

```haskell
{-# LANGUAGE DeriveGeneric, OverloadedStrings, OverloadedLabels #-}

module Lib where

import Database.Selda
import Database.Selda.SQLite
import qualified Streaming.Prelude as S

data Pet = Dog | Horse | Dragon
  deriving (Show, Read, Bounded, Enum)
instance SqlType Pet

data Person = Person
  { name :: Text
  , age  :: Int
  , pet  :: Maybe Pet
  } deriving (Generic, Show)
instance SqlRow Person

people :: Table Person
people = table "people" [#name :- primary]

prep = do
    createTable people
    insert_
      people
      [ Person "Velvet" 19 (Just Dog)
      , Person "Kobayashi" 23 (Just Dragon)
      , Person "Miyu" 10 Nothing
      ]
    let q = do
          person <- select people
          restrict (person ! #age .>= 18)
          return (person ! #name :*: person ! #pet)
    return q

-- since our stream is Monoid of (), we can use print
main :: IO ()
main =
  withSQLite "people.sqlite" $ do
    q <- prep
    forQuery q $ liftIO . print

-- instead of print, now, we use the singleton function of our streaming library,
-- in our example streaming it is `S.yield`
main2 :: IO ()
main2 =
  withSQLite "people.sqlite" $ do
    q <- prep
    a <- forQuery q $ pure . S.yield
    S.print a

-- since we can use Monoids to construct a list, this is how we get back to the "usual" list
main3 :: IO ()
main3 = 
  withSQLite "people.sqlite" $ do
    q <- prep
    a <- forQuery q $ pure . (:[])
    liftIO $ print a
```