### PR TITLE
bump time dep to 1.16

### DIFF
--- a/selda-build-tools.cabal
+++ b/selda-build-tools.cabal
@@ -10,7 +10,7 @@ executable selda-changelog
   main-is: ChangeLog.hs
   build-depends:
     base     >=4.8 && <5,
-    time     >=1.5 && <1.16,
+    time     >=1.5 && <1.17,
     filepath >=1.4 && <1.6,
     process  >=1.5 && <1.7
   default-language: Haskell2010

--- a/selda-postgresql/selda-postgresql.cabal
+++ b/selda-postgresql/selda-postgresql.cabal
@@ -32,7 +32,7 @@ library
     , text              >=1.0  && <2.2
     , postgresql-binary >=0.12 && <0.15
     , postgresql-libpq  >=0.9  && <0.12
-    , time              >=1.5  && <1.16
+    , time              >=1.5  && <1.17
     , uuid-types        >=1.0  && <1.1
   hs-source-dirs:
     src

--- a/selda-sqlite/selda-sqlite.cabal
+++ b/selda-sqlite/selda-sqlite.cabal
@@ -28,7 +28,7 @@ library
     , direct-sqlite >=2.2   && <2.4
     , directory     >=1.2.2 && <1.4
     , exceptions    >=0.8   && <0.11
-    , time          >=1.5   && <1.13
+    , time          >=1.5   && <1.17
     , uuid-types    >=1.0   && <1.1
   hs-source-dirs:
     src

--- a/selda-tests/selda-tests.cabal
+++ b/selda-tests/selda-tests.cabal
@@ -41,7 +41,7 @@ test-suite selda-testsuite
     , selda
     , selda-json
     , text       >=1.1  && <2.2
-    , time       >=1.4  && <1.16
+    , time       >=1.4  && <1.17
     , random     >=1.1  && <1.4
     , uuid-types >=1.0  && <1.1
   if flag(postgres)

--- a/selda/selda.cabal
+++ b/selda/selda.cabal
@@ -78,7 +78,7 @@ library
     , exceptions >=0.8  && <0.11
     , mtl        >=2.0  && <2.4
     , text       >=1.0  && <2.2
-    , time       >=1.5  && <1.16
+    , time       >=1.5  && <1.17
     , containers >=0.4  && <0.9
     , random     >=1.1  && <1.4
     , uuid-types >=1.0  && <1.1


### PR DESCRIPTION
Got a notice from hackage today; tests seem to be OK with `--allow-newer=time`. The deps (mainly `unix`) didn't grab the version bump yet so this is probably not urgent.