### PR TITLE
bump compat to allow aeson-2.3.0.0

### DIFF
--- a/selda-json/selda-json.cabal
+++ b/selda-json/selda-json.cabal
@@ -18,7 +18,7 @@ library
   exposed-modules:
     Database.Selda.JSON
   build-depends:
-      aeson      >=1.0  && <2.3
+      aeson      >=1.0  && <2.4
     , base       >=4.9  && <5
     , bytestring >=0.10 && <0.13
     , selda      >=0.4  && <0.6


### PR DESCRIPTION
Changelog here: https://hackage.haskell.org/package/aeson-2.3.0.0/changelog

I don't think we're affected, tests seem okay-ish with the new version.